### PR TITLE
feat: secure JWT with httpOnly cookies and enhance tx retry queue

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,12 @@ MONGODB_URI=mongodb://localhost:27017/oryn-finance
 # JWT Configuration
 #JWT_SECRET=your-super-secret-jwt-key-change-in-production
 #JWT_EXPIRES_IN=7d
+# Issue #22: use a separate secret for refresh tokens (falls back to JWT_SECRET if unset)
+#REFRESH_TOKEN_SECRET=your-refresh-token-secret-change-in-production
+
+# Issue #23: transaction retry settings
+#TX_RETRY_ATTEMPTS=4
+#TX_RETRY_BACKOFF_MS=2000
 
 # Stellar Configuration
 STELLAR_NETWORK=testnet

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
   "author": "Oryn Finance Team",
   "license": "MIT",
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "express": "^4.19.2",
     "mongoose": "^8.1.1",
     "stellar-sdk": "^12.0.1",

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const morgan = require('morgan');
 const rateLimit = require('express-rate-limit');
+const cookieParser = require('cookie-parser'); // Issue #22: parse httpOnly cookies
 const { createServer } = require('http');
 const { Server } = require('socket.io');
 require('dotenv').config();
@@ -12,6 +13,7 @@ const logger = require('./src/config/logger');
 const { errorHandler, notFound } = require('./src/middleware/errorHandler');
 
 // Import routes
+const authRoutes = require('./src/routes/auth');       // Issue #22: httpOnly cookie auth
 const healthRoutes = require('./src/routes/health');
 const marketRoutes = require('./src/routes/markets');
 const tradeRoutes = require('./src/routes/trades');
@@ -25,6 +27,7 @@ const adminRoutes = require('./src/routes/admin');
 const backgroundJobs = require('./src/services/backgroundJobs');
 const websocketHandler = require('./src/services/websocketHandler');
 const contractEventIndexer = require('./src/services/contractEventIndexer');
+const transactionRetryQueue = require('./src/services/transactionRetryQueue'); // Issue #23
 
 class OrynBackendServer {
   constructor() {
@@ -117,6 +120,9 @@ class OrynBackendServer {
     this.app.use(express.json({ limit: '10mb' }));
     this.app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
+    // Cookie parser — required for httpOnly JWT cookie support (Issue #22)
+    this.app.use(cookieParser());
+
     // Logging middleware
     if (process.env.NODE_ENV === 'development') {
       this.app.use(morgan('dev'));
@@ -145,6 +151,9 @@ class OrynBackendServer {
   }
 
   setupRoutes() {
+    // Auth routes — refresh token, logout (Issue #22)
+    this.app.use('/api/auth', authRoutes);
+
     // Health check (no authentication required)
     this.app.use('/api/health', healthRoutes);
 
@@ -181,6 +190,10 @@ class OrynBackendServer {
 
   setupWebSocket() {
     websocketHandler.initialize(this.io);
+
+    // Issue #23: inject Socket.io into the retry queue so it can notify users
+    transactionRetryQueue.injectIo(this.io);
+
     logger.info('WebSocket handlers initialized');
   }
 

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -7,11 +7,40 @@ const REFRESH_TOKEN_EXPIRY = '30d';
 const ACCESS_TOKEN_EXPIRY = '15m';
 const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || process.env.JWT_SECRET;
 
+// ── Cookie helpers (Issue #22) ────────────────────────────────────────────────
+
+const COOKIE_ACCESS  = 'oryn_access';
+const COOKIE_REFRESH = 'oryn_refresh';
+const IS_PROD        = process.env.NODE_ENV === 'production';
+
+/**
+ * Write access + refresh tokens into httpOnly, SameSite=Strict cookies.
+ * httpOnly prevents JS access (XSS mitigation).
+ * Secure flag is set in production so cookies travel only over HTTPS.
+ */
+function setAuthCookies(res, { accessToken, refreshToken }) {
+  const base = { httpOnly: true, sameSite: 'strict', secure: IS_PROD };
+  res.cookie(COOKIE_ACCESS,  accessToken,  { ...base, maxAge: 15 * 60 * 1000 });         // 15 min
+  res.cookie(COOKIE_REFRESH, refreshToken, { ...base, maxAge: 30 * 24 * 60 * 60 * 1000 }); // 30 days
+}
+
+/**
+ * Clear both auth cookies (called on logout).
+ */
+function clearAuthCookies(res) {
+  const base = { httpOnly: true, sameSite: 'strict', secure: IS_PROD };
+  res.clearCookie(COOKIE_ACCESS,  base);
+  res.clearCookie(COOKIE_REFRESH, base);
+}
+
 class AuthMiddleware {
   static async authenticateToken(req, res, next) {
     try {
-      const authHeader = req.headers['authorization'];
-      const token = authHeader && authHeader.split(' ')[1]; // Bearer TOKEN
+      // Accept token from httpOnly cookie first, then fall back to Bearer header
+      const cookieToken = req.cookies?.[COOKIE_ACCESS];
+      const authHeader  = req.headers['authorization'];
+      const headerToken = authHeader && authHeader.split(' ')[1];
+      const token       = cookieToken || headerToken;
 
       if (!token) {
         return res.status(401).json({
@@ -338,5 +367,9 @@ module.exports = {
   requireAdmin: AuthMiddleware.requireAdmin,
   requireMarketCreator: AuthMiddleware.requireMarketCreator,
   checkRateLimit: AuthMiddleware.checkRateLimit,
+  setAuthCookies,
+  clearAuthCookies,
+  COOKIE_ACCESS,
+  COOKIE_REFRESH,
   TokenService
 };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const router = express.Router();
+const { asyncHandler } = require('../middleware/errorHandler');
+const {
+  TokenService,
+  setAuthCookies,
+  clearAuthCookies,
+  COOKIE_REFRESH,
+} = require('../middleware/auth');
+const logger = require('../config/logger');
+
+/**
+ * POST /auth/refresh
+ * Issue a new access + refresh token pair using the httpOnly refresh cookie.
+ * The old refresh token is rotated (one-time use), preventing replay attacks.
+ */
+router.post('/refresh', asyncHandler(async (req, res) => {
+  const refreshToken = req.cookies?.[COOKIE_REFRESH];
+
+  if (!refreshToken) {
+    return res.status(401).json({ success: false, message: 'Refresh token required' });
+  }
+
+  const tokens = await TokenService.rotateTokens(refreshToken);
+  setAuthCookies(res, tokens);
+
+  logger.info('Tokens refreshed via cookie');
+
+  return res.json({
+    success: true,
+    message: 'Tokens refreshed',
+    expiresIn: tokens.expiresIn,
+  });
+}));
+
+/**
+ * POST /auth/logout
+ * Clear both auth cookies, effectively ending the session.
+ */
+router.post('/logout', (req, res) => {
+  clearAuthCookies(res);
+  logger.info('User logged out — auth cookies cleared');
+  return res.json({ success: true, message: 'Logged out' });
+});
+
+/**
+ * POST /auth/token
+ * Exchange a wallet challenge + signature for httpOnly auth cookies.
+ * Clients that previously stored tokens in localStorage should migrate here.
+ */
+router.post('/token', asyncHandler(async (req, res) => {
+  const { walletAddress, signature, challenge } = req.body;
+
+  if (!walletAddress || !signature || !challenge) {
+    return res.status(400).json({
+      success: false,
+      message: 'walletAddress, signature, and challenge are required',
+    });
+  }
+
+  // generateAuthToken validates the signature internally
+  await TokenService.generateAuthToken(walletAddress, signature, challenge);
+
+  const accessToken  = TokenService.generateAccessToken(walletAddress);
+  const refreshToken = TokenService.generateRefreshToken(walletAddress);
+
+  // Set tokens as httpOnly cookies — JS cannot read these (XSS protection)
+  setAuthCookies(res, { accessToken, refreshToken });
+
+  logger.info('Auth cookies issued', { walletAddress: walletAddress.slice(0, 10) + '...' });
+
+  return res.json({
+    success: true,
+    message: 'Authenticated — tokens stored in httpOnly cookies',
+    expiresIn: 900, // 15 min for access token
+  });
+}));
+
+module.exports = router;

--- a/backend/src/services/transactionRetryQueue.js
+++ b/backend/src/services/transactionRetryQueue.js
@@ -2,99 +2,189 @@ const logger = require('../config/logger');
 const sorobanService = require('./sorobanService');
 
 const MAX_ATTEMPTS = parseInt(process.env.TX_RETRY_ATTEMPTS || '4', 10);
-const BACKOFF_MS = parseInt(process.env.TX_RETRY_BACKOFF_MS || '2000', 10);
+const BACKOFF_MS    = parseInt(process.env.TX_RETRY_BACKOFF_MS || '2000', 10);
 
 /**
  * Lightweight in-process retry queue for Soroban submissions.
- * Production deployments can swap this for Redis-backed Bull workers; the API surface stays the same.
+ * Production deployments can swap this for Redis-backed Bull workers;
+ * the public API surface stays the same.
+ *
+ * Issue #23: enhanced with
+ *   - Trade model status updates (pending → confirmed | failed)
+ *   - WebSocket notifications to the owning wallet on each outcome
  */
 class TransactionRetryQueue {
   constructor() {
-    this.isEnabled = true;
-    this.recentFailures = [];
+    this.isEnabled       = true;
+    this.recentFailures  = [];
     this.recentSuccesses = [];
+    this._io             = null; // injected after server starts
+  }
+
+  /**
+   * Inject the Socket.io server instance so the queue can push real-time
+   * notifications to connected clients.
+   *
+   * @param {import('socket.io').Server} io
+   */
+  injectIo(io) {
+    this._io = io;
   }
 
   /**
    * Schedule background retries with exponential backoff.
+   *
+   * @param {{ signedXDR: string, txHash: string, tradeId?: string, walletAddress?: string }} options
    */
-  enqueue({ signedXDR, txHash }) {
+  enqueue({ signedXDR, txHash, tradeId, walletAddress }) {
     const jobId = `tx_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
     const job = {
       jobId,
       signedXDR,
       txHash,
-      attempt: 0
+      tradeId:       tradeId       || null,
+      walletAddress: walletAddress || null,
+      attempt:       0,
     };
 
-    setImmediate(() => this.processJob(job));
+    setImmediate(() => this._processJob(job));
 
-    return {
-      queued: true,
-      jobId
-    };
+    logger.info('Transaction enqueued for retry', { jobId, tradeId, attempt: 0 });
+
+    return { queued: true, jobId };
   }
 
-  async processJob(job) {
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  async _processJob(job) {
     try {
       const result = await sorobanService.submitSignedTransaction(job.signedXDR);
-      this.recordSuccess(job, result);
+      await this._handleSuccess(job, result);
     } catch (error) {
       job.attempt += 1;
 
       logger.warn('Transaction submit attempt failed', {
-        jobId: job.jobId,
+        jobId:   job.jobId,
         attempt: job.attempt,
-        message: error.message
+        message: error.message,
       });
 
       if (job.attempt < MAX_ATTEMPTS) {
         const delay = BACKOFF_MS * Math.pow(2, job.attempt - 1);
-        setTimeout(() => this.processJob(job), delay);
+        setTimeout(() => this._processJob(job), delay);
       } else {
-        this.recordFailure(job, error);
+        await this._handleExhausted(job, error);
       }
     }
   }
 
-  recordSuccess(job, result) {
+  async _handleSuccess(job, result) {
+    // Update Trade document if we have a tradeId
+    if (job.tradeId) {
+      try {
+        const { Trade } = require('../models');
+        await Trade.findOneAndUpdate(
+          { tradeId: job.tradeId },
+          {
+            status: 'confirmed',
+            'txDetails.stellarTxHash': result?.hash || job.txHash || null,
+            confirmedAt: new Date(),
+          }
+        );
+      } catch (dbErr) {
+        logger.warn('Could not update Trade on retry success (non-DB mode?)', { error: dbErr.message });
+      }
+    }
+
+    // Notify the owning wallet via WebSocket
+    this._notify(job.walletAddress, {
+      event:   'tx:confirmed',
+      jobId:   job.jobId,
+      tradeId: job.tradeId,
+      txHash:  result?.hash || job.txHash || null,
+      message: 'Your transaction was confirmed after retry.',
+    });
+
     this.recentSuccesses.unshift({
-      jobId: job.jobId,
-      txHash: result?.hash || job.txHash || null,
-      recoveredAt: new Date().toISOString()
+      jobId:       job.jobId,
+      txHash:      result?.hash || job.txHash || null,
+      tradeId:     job.tradeId,
+      recoveredAt: new Date().toISOString(),
     });
     this.recentSuccesses = this.recentSuccesses.slice(0, 50);
 
     logger.info('Background transaction retry succeeded', {
-      jobId: job.jobId,
-      txHash: result?.hash || null
+      jobId:  job.jobId,
+      txHash: result?.hash || null,
     });
   }
 
-  recordFailure(job, error) {
+  async _handleExhausted(job, error) {
+    // Mark Trade as permanently failed
+    if (job.tradeId) {
+      try {
+        const { Trade } = require('../models');
+        await Trade.findOneAndUpdate(
+          { tradeId: job.tradeId },
+          {
+            status:     'failed',
+            failReason: `Retries exhausted after ${job.attempt} attempts: ${error.message}`,
+          }
+        );
+      } catch (dbErr) {
+        logger.warn('Could not update Trade on retry exhaustion (non-DB mode?)', { error: dbErr.message });
+      }
+    }
+
+    // Notify user of permanent failure
+    this._notify(job.walletAddress, {
+      event:   'tx:failed',
+      jobId:   job.jobId,
+      tradeId: job.tradeId,
+      message: `Transaction failed after ${job.attempt} retry attempts. Please try again.`,
+      error:   error.message,
+    });
+
     this.recentFailures.unshift({
-      jobId: job.jobId,
-      txHash: job.txHash || null,
+      jobId:    job.jobId,
+      txHash:   job.txHash || null,
+      tradeId:  job.tradeId,
       attempts: job.attempt,
-      message: error.message,
-      failedAt: new Date().toISOString()
+      message:  error.message,
+      failedAt: new Date().toISOString(),
     });
     this.recentFailures = this.recentFailures.slice(0, 100);
 
     logger.error('Background transaction retries exhausted', {
-      jobId: job.jobId,
+      jobId:    job.jobId,
       attempts: job.attempt,
-      error: error.message
+      error:    error.message,
     });
+  }
+
+  /**
+   * Emit a real-time notification to a wallet's socket room.
+   * Clients join a room named after their wallet address on connect.
+   */
+  _notify(walletAddress, payload) {
+    if (!walletAddress) return;
+
+    if (this._io) {
+      this._io.to(walletAddress.toLowerCase()).emit('notification', payload);
+    } else {
+      logger.warn('TransactionRetryQueue: Socket.io not injected — skipping real-time notification', {
+        event: payload.event,
+      });
+    }
   }
 
   getRecoverySnapshot() {
     return {
-      queueEnabled: this.isEnabled,
-      maxAttempts: MAX_ATTEMPTS,
-      backoffMs: BACKOFF_MS,
-      recentFailures: this.recentFailures,
-      recentRecoveries: this.recentSuccesses
+      queueEnabled:     this.isEnabled,
+      maxAttempts:      MAX_ATTEMPTS,
+      backoffMs:        BACKOFF_MS,
+      recentFailures:   this.recentFailures,
+      recentRecoveries: this.recentSuccesses,
     };
   }
 }


### PR DESCRIPTION
Closes #22
Closes #23

## What changed

### Issue #22 — Secure JWT token storage
- Added `cookie-parser` middleware to `server.js`
- `auth.js`: access token is now read from the `oryn_access` httpOnly cookie first, with `Authorization: Bearer` header as a fallback (backward compatible)
- Added `setAuthCookies()` / `clearAuthCookies()` helpers — cookies are set with `httpOnly: true`, `sameSite: 'strict'`, and `secure: true` in production so JavaScript cannot read them (XSS mitigation)
- **`POST /api/auth/token`** — exchanges a wallet challenge + signature for httpOnly cookies instead of exposing tokens in the response body
- **`POST /api/auth/refresh`** — reads the `oryn_refresh` cookie, rotates it (one-time use), and writes fresh `oryn_access` + `oryn_refresh` cookies
- **`POST /api/auth/logout`** — clears both auth cookies

### Issue #23 — Retry mechanism for failed trades
- `transactionRetryQueue.enqueue()` now accepts `tradeId` and `walletAddress`
- **On success**: updates `Trade.status → 'confirmed'` and emits a `tx:confirmed` Socket.io notification to the wallet's room
- **On exhaustion**: updates `Trade.status → 'failed'` with `failReason` message and emits a `tx:failed` notification so the user is alerted in real time
- `injectIo(io)` method wired in `server.js` `setupWebSocket()` so the singleton queue receives the live Socket.io instance at startup

## How to test
- Call `POST /api/auth/token` with a valid wallet challenge — inspect cookies in DevTools; no token in response body
- Call `POST /api/auth/refresh` — old refresh cookie is replaced with a new one
- Call `POST /api/auth/logout` — both cookies are cleared
- Trigger a failing Soroban transaction — observe `Trade.status` flip to `failed` and a WebSocket `tx:failed` notification delivered to the wallet room