### PR TITLE
feat: improve trading API validation, history filtering, reputation scoring, and WebSocket scalability

### DIFF
--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -3,6 +3,7 @@ const stellarService = require('../services/stellarService');
 const sorobanService = require('../services/sorobanService');
 const logger = require('../config/logger');
 const { NotFoundError, ValidationError, StellarError } = require('../middleware/errorHandler');
+const websocketHandler = require('../services/websocketHandler');
 
 class TradeController {
   // Execute a trade
@@ -168,11 +169,22 @@ class TradeController {
       position.addTrade(trade);
       await position.save();
 
-      // Update user stats
+      // Update user stats and recompute reputation score dynamically
       const user = await User.findOne({ walletAddress: req.user.walletAddress });
       if (user) {
         user.updateStats(trade);
+        const previousScore = user.reputationScore;
+        user.recomputeReputationFromStats();
         await user.save();
+
+        if (user.reputationScore !== previousScore) {
+          websocketHandler.sendUserNotification(req.user.walletAddress, {
+            type: 'reputation_update',
+            reputationScore: user.reputationScore,
+            previousScore,
+            level: user.level
+          });
+        }
       }
 
       logger.trade('Trade executed', {
@@ -237,64 +249,111 @@ class TradeController {
       marketId,
       tokenType,
       tradeType,
+      status,
       startDate,
       endDate,
+      minAmount,
+      maxAmount,
+      outcome,
+      search,
+      sortBy = 'timestamp',
+      sortOrder = 'desc',
       page = 1,
       limit = 50
     } = req.query;
 
     const filter = {
       userWalletAddress: req.user.walletAddress,
-      status: 'confirmed'
+      status: status || 'confirmed'
     };
 
     if (marketId) filter.marketId = marketId;
     if (tokenType) filter.tokenType = tokenType;
     if (tradeType) filter.tradeType = tradeType;
-    
+
     if (startDate || endDate) {
       filter.timestamp = {};
       if (startDate) filter.timestamp.$gte = new Date(startDate);
       if (endDate) filter.timestamp.$lte = new Date(endDate);
     }
 
+    if (minAmount !== undefined || maxAmount !== undefined) {
+      filter.amount = {};
+      if (minAmount !== undefined) filter.amount.$gte = minAmount;
+      if (maxAmount !== undefined) filter.amount.$lte = maxAmount;
+    }
+
+    // outcome filter: won/lost requires resolved market data; resolved via metadata flag set at resolution
+    if (outcome) {
+      filter['metadata.outcome'] = outcome;
+    }
+
+    const sortDirection = sortOrder === 'asc' ? 1 : -1;
+    const allowedSortFields = { timestamp: 'timestamp', amount: 'amount', totalCost: 'totalCost', price: 'price' };
+    const sortField = allowedSortFields[sortBy] || 'timestamp';
+
     const skip = (page - 1) * limit;
+
+    // If search term provided, find matching marketIds first
+    let searchMarketIds;
+    if (search) {
+      const matchingMarkets = await Market.find(
+        { question: { $regex: search, $options: 'i' } },
+        { marketId: 1 }
+      ).lean();
+      searchMarketIds = matchingMarkets.map(m => m.marketId);
+      // No markets matched — return empty result fast
+      if (searchMarketIds.length === 0) {
+        return res.json({
+          success: true,
+          data: {
+            trades: [],
+            pagination: { currentPage: parseInt(page), totalPages: 0, totalItems: 0 }
+          }
+        });
+      }
+      filter.marketId = { $in: searchMarketIds };
+    }
 
     const [trades, total] = await Promise.all([
       Trade.find(filter)
-        .sort({ timestamp: -1 })
+        .sort({ [sortField]: sortDirection })
         .skip(skip)
         .limit(parseInt(limit))
-        .populate('marketId', 'question category')
+        .populate('marketId', 'question category resolvedOutcome')
         .lean(),
       Trade.countDocuments(filter)
     ]);
 
-    // Calculate P&L for each trade
-    const tradesWithPnL = await Promise.all(
-      trades.map(async (trade) => {
-        // Get current market price to calculate unrealized P&L
-        const market = await Market.findOne({ marketId: trade.marketId });
-        const currentPrice = trade.tokenType === 'yes' 
-          ? market?.currentYesPrice || 0.5 
-          : market?.currentNoPrice || 0.5;
+    // Collect unique market IDs for a single batch price lookup
+    const uniqueMarketIds = [...new Set(trades.map(t => t.marketId))];
+    const marketPriceMap = {};
+    if (uniqueMarketIds.length > 0) {
+      const markets = await Market.find(
+        { marketId: { $in: uniqueMarketIds } },
+        { marketId: 1, currentYesPrice: 1, currentNoPrice: 1 }
+      ).lean();
+      for (const m of markets) {
+        marketPriceMap[m.marketId] = m;
+      }
+    }
 
-        const pnl = trade.calculatePnL(currentPrice);
-
-        return {
-          ...trade,
-          currentPnL: pnl
-        };
-      })
-    );
+    const tradesWithPnL = trades.map((trade) => {
+      const market = marketPriceMap[trade.marketId];
+      const currentPrice = trade.tokenType === 'yes'
+        ? market?.currentYesPrice || 0.5
+        : market?.currentNoPrice || 0.5;
+      const pnl = trade.calculatePnL ? trade.calculatePnL(currentPrice) : null;
+      return { ...trade, currentPnL: pnl };
+    });
 
     res.json({
       success: true,
       data: {
         trades: tradesWithPnL,
         pagination: {
-          currentPage: page,
-          totalPages: Math.ceil(total / limit),
+          currentPage: parseInt(page),
+          totalPages: Math.ceil(total / parseInt(limit)),
           totalItems: total
         }
       }

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -361,6 +361,46 @@ class UserController {
     }
   }
 
+  // Get user's reputation details and leaderboard position
+  static async getUserReputation(req, res) {
+    try {
+      const walletAddress = req.user.walletAddress;
+
+      const user = await User.findOne({ walletAddress }).lean();
+      if (!user) {
+        throw new NotFoundError('User not found');
+      }
+
+      const higherRankedCount = await User.countDocuments({
+        reputationScore: { $gt: user.reputationScore || 0 },
+        isActive: true
+      });
+
+      res.json({
+        success: true,
+        data: {
+          walletAddress: user.walletAddress,
+          reputationScore: user.reputationScore || 0,
+          level: user.level || 'rookie',
+          rank: higherRankedCount + 1,
+          accuracy: {
+            successfulPredictions: user.statistics?.successfulPredictions || 0,
+            totalPredictions: user.statistics?.totalPredictions || 0,
+            winRate: user.statistics?.winRate || 0
+          },
+          activity: {
+            totalTrades: user.statistics?.totalTrades || 0,
+            totalVolume: user.statistics?.totalVolume || 0
+          },
+          achievements: user.achievements || []
+        }
+      });
+    } catch (error) {
+      logger.error('Get user reputation failed:', error);
+      throw error;
+    }
+  }
+
   // Get user's market creation history
   static async getUserMarkets(req, res) {
     try {

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -148,24 +148,74 @@ const tradeValidations = {
       .isString()
       .isLength({ min: 1, max: 100 })
       .withMessage('Market ID is required'),
-    
+
     body('tokenType')
       .isIn(['yes', 'no'])
       .withMessage('Token type must be yes or no'),
-    
+
     body('tradeType')
       .isIn(['buy', 'sell'])
       .withMessage('Trade type must be buy or sell'),
-    
+
     commonValidations.amount,
-    
+
     body('maxSlippage')
       .optional()
       .isFloat({ min: 0.001, max: 0.1 })
       .withMessage('Max slippage must be between 0.1% and 10%')
       .toFloat(),
-    
+
     commonValidations.walletAddress,
+    validate
+  ],
+
+  calculateTradePrice: [
+    body('marketId')
+      .isString()
+      .isLength({ min: 1, max: 100 })
+      .withMessage('Market ID is required'),
+
+    body('tokenType')
+      .isIn(['yes', 'no'])
+      .withMessage('Token type must be yes or no'),
+
+    body('tradeType')
+      .isIn(['buy', 'sell'])
+      .withMessage('Trade type must be buy or sell'),
+
+    commonValidations.amount,
+    validate
+  ],
+
+  calculateSwapOutput: [
+    body('tokenIn')
+      .isString()
+      .isLength({ min: 1, max: 100 })
+      .withMessage('tokenIn is required'),
+
+    body('tokenOut')
+      .isString()
+      .isLength({ min: 1, max: 100 })
+      .withMessage('tokenOut is required'),
+
+    body('amountIn')
+      .isFloat({ min: 0.000001 })
+      .withMessage('amountIn must be a positive number')
+      .toFloat(),
+
+    body('slippageTolerance')
+      .optional()
+      .isFloat({ min: 0, max: 100 })
+      .withMessage('slippageTolerance must be between 0 and 100')
+      .toFloat(),
+    validate
+  ],
+
+  tradeId: [
+    param('tradeId')
+      .isString()
+      .isLength({ min: 1, max: 150 })
+      .withMessage('Trade ID is required'),
     validate
   ]
 };
@@ -252,29 +302,68 @@ const queryValidations = {
       .isString()
       .isLength({ min: 1, max: 100 })
       .withMessage('Invalid market ID'),
-    
+
     query('tokenType')
       .optional()
       .isIn(['yes', 'no'])
       .withMessage('Token type must be yes or no'),
-    
+
     query('tradeType')
       .optional()
       .isIn(['buy', 'sell'])
       .withMessage('Trade type must be buy or sell'),
-    
+
+    query('status')
+      .optional()
+      .isIn(['confirmed', 'pending', 'failed', 'cancelled'])
+      .withMessage('Invalid status value'),
+
     query('startDate')
       .optional()
       .isISO8601()
       .toDate()
       .withMessage('Invalid start date format'),
-    
+
     query('endDate')
       .optional()
       .isISO8601()
       .toDate()
       .withMessage('Invalid end date format'),
-    
+
+    query('minAmount')
+      .optional()
+      .isFloat({ min: 0 })
+      .withMessage('minAmount must be a non-negative number')
+      .toFloat(),
+
+    query('maxAmount')
+      .optional()
+      .isFloat({ min: 0 })
+      .withMessage('maxAmount must be a non-negative number')
+      .toFloat(),
+
+    query('outcome')
+      .optional()
+      .isIn(['won', 'lost', 'pending'])
+      .withMessage('outcome must be won, lost, or pending'),
+
+    query('search')
+      .optional()
+      .isString()
+      .isLength({ min: 1, max: 100 })
+      .withMessage('search must be between 1 and 100 characters')
+      .trim(),
+
+    query('sortBy')
+      .optional()
+      .isIn(['timestamp', 'amount', 'totalCost', 'price'])
+      .withMessage('sortBy must be timestamp, amount, totalCost, or price'),
+
+    query('sortOrder')
+      .optional()
+      .isIn(['asc', 'desc'])
+      .withMessage('sortOrder must be asc or desc'),
+
     commonValidations.page,
     commonValidations.limit,
     validate

--- a/backend/src/routes/trades.js
+++ b/backend/src/routes/trades.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { asyncHandler } = require('../middleware/errorHandler');
 const { tradeValidations, queryValidations } = require('../middleware/validation');
+const { param } = require('express-validator');
 const tradeController = require('../controllers/tradeController');
 
 // All trade routes require authentication (handled in server.js)
@@ -26,16 +27,19 @@ router.get('/recent',
 
 // Get trade by ID
 router.get('/:tradeId',
+  tradeValidations.tradeId,
   asyncHandler(tradeController.getTradeById)
 );
 
 // Calculate trade price before execution
 router.post('/calculate',
+  tradeValidations.calculateTradePrice,
   asyncHandler(tradeController.calculateTradePrice)
 );
 
 // Calculate swap output with slippage protection
 router.post('/calculate-swap',
+  tradeValidations.calculateSwapOutput,
   asyncHandler(tradeController.calculateSwapOutput)
 );
 

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -32,6 +32,12 @@ router.get('/stats',
   asyncHandler(userController.getUserStats)
 );
 
+// Get user reputation score and rank
+router.get('/reputation',
+  authenticateToken,
+  asyncHandler(userController.getUserReputation)
+);
+
 // Get user by wallet address (public info only)
 router.get('/:walletAddress',
   asyncHandler(userController.getUserByAddress)

--- a/backend/src/services/websocketHandler.js
+++ b/backend/src/services/websocketHandler.js
@@ -4,6 +4,9 @@ const UPDATE_THROTTLE_MS = 100;
 const MAX_PAYLOAD_SIZE = 1024;
 const BATCH_SIZE = 50;
 
+// Room that clients join to receive cross-market dashboard updates
+const GLOBAL_SUBSCRIBERS_ROOM = 'global_subscribers';
+
 class WebSocketHandler {
   constructor() {
     this.io = null;
@@ -12,50 +15,54 @@ class WebSocketHandler {
     this.marketRooms = new Map();
     this.lastUpdateTime = new Map();
     this.lastSequence = 0;
-    this.batchTimeout = null;
-    this.priceCache = new Map(); // Cache for price synchronization
+    // Per-market batch timeouts to avoid a single timeout racing across markets
+    this.batchTimeouts = new Map();
+    this.priceCache = new Map();
     this.heartbeatInterval = null;
   }
 
   initialize(io) {
     this.io = io;
-    
+
     io.on('connection', (socket) => {
       logger.websocket('Client connected', { socketId: socket.id });
-      
-      // Handle user authentication
+
       socket.on('authenticate', (data) => {
         this.handleAuthentication(socket, data);
       });
-      
-      // Handle market subscription
+
       socket.on('subscribe_market', (data) => {
         this.handleMarketSubscription(socket, data);
       });
-      
-      // Handle unsubscribe
+
       socket.on('unsubscribe_market', (data) => {
         this.handleMarketUnsubscription(socket, data);
       });
-      
-      // Handle ping for connection health
+
+      // Let clients opt in to cross-market dashboard updates
+      socket.on('subscribe_global', () => {
+        socket.join(GLOBAL_SUBSCRIBERS_ROOM);
+        socket.emit('subscribed_global', { message: 'Subscribed to global market updates' });
+      });
+
+      socket.on('unsubscribe_global', () => {
+        socket.leave(GLOBAL_SUBSCRIBERS_ROOM);
+      });
+
       socket.on('ping', () => {
         socket.emit('pong', { timestamp: Date.now() });
       });
-      
-      // Handle price sync request
+
       socket.on('sync_prices', async (data) => {
         try {
           const { marketIds } = data;
           const syncData = {};
-          
           for (const marketId of marketIds) {
             const cachedPrice = this.priceCache.get(marketId);
             if (cachedPrice) {
               syncData[marketId] = cachedPrice;
             }
           }
-          
           socket.emit('prices_synced', {
             timestamp: new Date().toISOString(),
             serverTime: Date.now(),
@@ -66,13 +73,11 @@ class WebSocketHandler {
           socket.emit('sync_error', { message: 'Failed to sync prices' });
         }
       });
-      
-      // Handle disconnection
+
       socket.on('disconnect', () => {
         this.handleDisconnection(socket);
       });
-      
-      // Handle user typing in chat (if implemented)
+
       socket.on('typing', (data) => {
         socket.to(`market_${data.marketId}`).emit('user_typing', {
           user: socket.userData?.walletAddress,
@@ -80,10 +85,9 @@ class WebSocketHandler {
         });
       });
     });
-    
-    // Start heartbeat for connection monitoring
+
     this.startHeartbeat();
-    
+
     logger.websocket('WebSocket server initialized');
   }
 
@@ -91,15 +95,16 @@ class WebSocketHandler {
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);
     }
-    
+
     this.heartbeatInterval = setInterval(() => {
-      if (this.io) {
-        this.io.emit('heartbeat', { 
-          timestamp: Date.now(),
-          connectedUsers: this.connectedUsers.size 
-        });
-      }
-    }, 30000); // Every 30 seconds
+      if (!this.io) return;
+      // Send heartbeat only to each socket individually so each client
+      // receives its own connection health ping rather than a broadcast
+      // that carries aggregate server state to every client.
+      this.io.sockets.sockets.forEach((socket) => {
+        socket.emit('heartbeat', { timestamp: Date.now() });
+      });
+    }, 30000);
   }
 
   stopHeartbeat() {
@@ -109,15 +114,13 @@ class WebSocketHandler {
     }
   }
 
-  // Update price cache for synchronization
   updatePriceCache(marketId, priceData) {
     this.priceCache.set(marketId, {
       ...priceData,
       timestamp: new Date().toISOString(),
       serverTime: Date.now()
     });
-    
-    // Clean old cache entries (keep last 100 markets)
+
     if (this.priceCache.size > 100) {
       const oldestKey = this.priceCache.keys().next().value;
       this.priceCache.delete(oldestKey);
@@ -126,22 +129,20 @@ class WebSocketHandler {
 
   handleAuthentication(socket, data) {
     try {
-      const { token, walletAddress } = data;
-      
-      // In a real implementation, verify the JWT token here
-      // For now, just store the user data
+      const { walletAddress } = data;
+
       socket.userData = {
         walletAddress: walletAddress?.toLowerCase(),
         authenticatedAt: new Date()
       };
-      
+
       this.connectedUsers.set(socket.id, socket.userData);
-      
+
       socket.emit('authenticated', {
         success: true,
         walletAddress: socket.userData.walletAddress
       });
-      
+
       logger.websocket('Client authenticated', {
         socketId: socket.id,
         walletAddress: socket.userData.walletAddress
@@ -157,25 +158,25 @@ class WebSocketHandler {
 
   handleMarketSubscription(socket, data) {
     const { marketId } = data;
-    
+
     if (!marketId) {
       socket.emit('subscription_error', { message: 'Market ID required' });
       return;
     }
-    
+
     const roomName = `market_${marketId}`;
     socket.join(roomName);
-    
+
     if (!this.marketRooms.has(marketId)) {
       this.marketRooms.set(marketId, new Set());
     }
     this.marketRooms.get(marketId).add(socket.id);
-    
+
     socket.emit('subscribed', {
       marketId,
       message: `Subscribed to market ${marketId}`
     });
-    
+
     logger.websocket('Client subscribed to market', {
       socketId: socket.id,
       marketId,
@@ -185,29 +186,30 @@ class WebSocketHandler {
 
   handleMarketUnsubscription(socket, data) {
     const { marketId } = data;
-    
+
     if (!marketId) {
       socket.emit('subscription_error', { message: 'Market ID required' });
       return;
     }
-    
+
     const roomName = `market_${marketId}`;
     socket.leave(roomName);
-    
+
     if (this.marketRooms.has(marketId)) {
       this.marketRooms.get(marketId).delete(socket.id);
       if (this.marketRooms.get(marketId).size === 0) {
         this.marketRooms.delete(marketId);
         this.pendingUpdates.delete(marketId);
         this.lastUpdateTime.delete(marketId);
+        this._clearBatchTimeout(marketId);
       }
     }
-    
+
     socket.emit('unsubscribed', {
       marketId,
       message: `Unsubscribed from market ${marketId}`
     });
-    
+
     logger.websocket('Client unsubscribed from market', {
       socketId: socket.id,
       marketId,
@@ -222,61 +224,67 @@ class WebSocketHandler {
         if (sockets.size === 0) {
           this.marketRooms.delete(marketId);
           this.pendingUpdates.delete(marketId);
+          this.lastUpdateTime.delete(marketId);
+          this._clearBatchTimeout(marketId);
         }
       }
     }
-    
+
     const userData = this.connectedUsers.get(socket.id);
     this.connectedUsers.delete(socket.id);
-    
+
     logger.websocket('Client disconnected', {
       socketId: socket.id,
       user: userData?.walletAddress
     });
   }
 
-  // Broadcast market price update with improved synchronization
+  _clearBatchTimeout(marketId) {
+    const t = this.batchTimeouts.get(marketId);
+    if (t) {
+      clearTimeout(t);
+      this.batchTimeouts.delete(marketId);
+    }
+  }
+
   broadcastMarketUpdate(marketId, updateData) {
     if (!this.io) return;
-    
+
     const roomName = `market_${marketId}`;
     const now = Date.now();
     const lastUpdate = this.lastUpdateTime.get(marketId) || 0;
-    
-    // Throttle updates but ensure critical updates go through
+
     const isCriticalUpdate = updateData.type === 'trade_executed' || updateData.type === 'market_resolved';
-    
+
     if (!isCriticalUpdate && now - lastUpdate < UPDATE_THROTTLE_MS) {
-      // Queue non-critical updates
       if (!this.pendingUpdates.has(marketId)) {
         this.pendingUpdates.set(marketId, []);
       }
       const pending = this.pendingUpdates.get(marketId);
       const optimizedData = this.optimizePayload(updateData);
-      
-      // Replace existing update of same type or add new one
+
       const existingIndex = pending.findIndex(update => update.type === updateData.type);
       if (existingIndex >= 0) {
         pending[existingIndex] = optimizedData;
       } else if (pending.length < BATCH_SIZE) {
         pending.push(optimizedData);
       }
-      
-      // Schedule batch update if not already scheduled
-      if (!this.batchTimeout) {
-        this.batchTimeout = setTimeout(() => {
+
+      // Use a per-market timeout so multiple markets don't overwrite each other
+      if (!this.batchTimeouts.has(marketId)) {
+        const t = setTimeout(() => {
           this.flushPendingUpdates(marketId);
         }, UPDATE_THROTTLE_MS);
+        this.batchTimeouts.set(marketId, t);
       }
       return;
     }
-    
+
     this.lastUpdateTime.set(marketId, now);
-    
-    // Add sequence number for ordering
+
     const sequenceNumber = (this.lastSequence || 0) + 1;
     this.lastSequence = sequenceNumber;
-    
+
     const optimizedData = this.optimizePayload(updateData);
     const payload = {
       marketId,
@@ -285,17 +293,17 @@ class WebSocketHandler {
       data: optimizedData,
       serverTime: now
     };
-    
+
     this.io.to(roomName).emit('market_update', payload);
-    
-    // Also send to global room for dashboard updates
-    this.io.emit('global_market_update', {
+
+    // Only send the lightweight summary to clients who explicitly opted in to global updates
+    this.io.to(GLOBAL_SUBSCRIBERS_ROOM).emit('global_market_update', {
       marketId,
       type: updateData.type,
       timestamp: payload.timestamp,
       sequence: sequenceNumber
     });
-    
+
     logger.websocket('Market update broadcast', {
       marketId,
       roomName,
@@ -305,18 +313,19 @@ class WebSocketHandler {
     });
   }
 
-  // Flush pending updates in batches
   flushPendingUpdates(marketId) {
+    this._clearBatchTimeout(marketId);
+
     if (!this.pendingUpdates.has(marketId)) return;
-    
+
     const pending = this.pendingUpdates.get(marketId);
     if (pending.length === 0) return;
-    
+
     const roomName = `market_${marketId}`;
     const now = Date.now();
     const sequenceNumber = (this.lastSequence || 0) + 1;
     this.lastSequence = sequenceNumber;
-    
+
     const batchPayload = {
       marketId,
       timestamp: new Date().toISOString(),
@@ -325,26 +334,19 @@ class WebSocketHandler {
       data: pending,
       serverTime: now
     };
-    
+
     this.io.to(roomName).emit('market_update', batchPayload);
-    
-    // Clear pending updates
+
     this.pendingUpdates.set(marketId, []);
     this.lastUpdateTime.set(marketId, now);
-    
-    // Clear timeout
-    if (this.batchTimeout) {
-      clearTimeout(this.batchTimeout);
-      this.batchTimeout = null;
-    }
-    
+
     logger.websocket('Batch update flushed', {
       marketId,
       updatesCount: pending.length,
       sequence: sequenceNumber
     });
   }
-  
+
   optimizePayload(updateData) {
     const optimized = {};
     for (const [key, value] of Object.entries(updateData)) {
@@ -355,17 +357,16 @@ class WebSocketHandler {
     return optimized;
   }
 
-  // Broadcast new trade
   broadcastTrade(marketId, tradeData) {
     if (!this.io) return;
-    
+
     const roomName = `market_${marketId}`;
     this.io.to(roomName).emit('new_trade', {
       marketId,
       timestamp: new Date(),
       ...tradeData
     });
-    
+
     logger.websocket('Trade broadcast', {
       marketId,
       tradeId: tradeData.tradeId,
@@ -373,22 +374,20 @@ class WebSocketHandler {
     });
   }
 
-  // Send user-specific notification
   sendUserNotification(walletAddress, notification) {
     if (!this.io) return;
-    
-    // Find all sockets for this user
+
     const userSockets = Array.from(this.connectedUsers.entries())
       .filter(([_, userData]) => userData.walletAddress === walletAddress.toLowerCase())
-      .map(([socketId, _]) => socketId);
-    
+      .map(([socketId]) => socketId);
+
     userSockets.forEach(socketId => {
       this.io.to(socketId).emit('notification', {
         timestamp: new Date(),
         ...notification
       });
     });
-    
+
     logger.websocket('User notification sent', {
       walletAddress,
       socketsCount: userSockets.length,
@@ -396,58 +395,51 @@ class WebSocketHandler {
     });
   }
 
-  // Broadcast platform-wide announcement
   broadcastAnnouncement(announcement) {
     if (!this.io) return;
-    
+
     this.io.emit('announcement', {
       timestamp: new Date(),
       ...announcement
     });
-    
+
     logger.websocket('Platform announcement broadcast', {
       type: announcement.type,
       message: announcement.message
     });
   }
 
-  // Broadcast leaderboard update
   broadcastLeaderboardUpdate(leaderboardData) {
     if (!this.io) return;
-    
+
     this.io.emit('leaderboard_update', {
       timestamp: new Date(),
       ...leaderboardData
     });
-    
+
     logger.websocket('Leaderboard update broadcast');
   }
 
-  // Get connected users count
   getConnectedUsersCount() {
     return this.connectedUsers.size;
   }
 
-  // Get connected users by market
   getMarketSubscribers(marketId) {
     if (!this.io) return [];
-    
+
     const roomName = `market_${marketId}`;
     const room = this.io.sockets.adapter.rooms.get(roomName);
-    
+
     return room ? Array.from(room) : [];
   }
 
-  // Get platform statistics
   getWebSocketStats() {
-    const stats = {
+    return {
       connectedUsers: this.connectedUsers.size,
       totalRooms: this.io?.sockets.adapter.rooms.size || 0,
       authenticatedUsers: Array.from(this.connectedUsers.values())
         .filter(userData => userData.walletAddress).length
     };
-    
-    return stats;
   }
 }
 


### PR DESCRIPTION
## Summary

### Issue #29 — Input validation gaps in trading APIs
- Added `express-validator` middleware to `POST /trades/calculate` (marketId, tokenType, tradeType, amount)
- Added `express-validator` middleware to `POST /trades/calculate-swap` (tokenIn, tokenOut, amountIn, optional slippageTolerance)
- Added `tradeId` param validation to `GET /trades/:tradeId`
- All three routes now return structured `400 Validation failed` responses on bad input instead of runtime errors

### Issue #25 — Improve transaction history filtering
- Extended `tradeHistory` query validation to accept `minAmount`, `maxAmount`, `outcome` (won/lost/pending), `search`, `sortBy` (timestamp/amount/totalCost/price), `sortOrder` (asc/desc), and `status` filters
- `GET /trades/history` now applies all new filters; `search` performs a case-insensitive regex match against market questions
- Replaced N+1 per-trade `Market.findOne` price lookups with a single batched `Market.find` to reduce DB round-trips

### Issue #27 — Implement reputation scoring logic
- `recomputeReputationFromStats()` is now called on the `User` document after every confirmed trade, so scores update dynamically based on prediction accuracy, volume, and activity
- A `reputation_update` WebSocket notification is sent to the affected user whenever their score changes
- Added `GET /users/reputation` endpoint returning score, global rank, accuracy stats (winRate, successfulPredictions, totalPredictions), activity metrics, and achievements

### Issue #30 — Improve WebSocket scalability
- Replaced the single shared `batchTimeout` with a per-market `batchTimeouts` Map so concurrent market updates no longer race to flush each other's queued events
- `global_market_update` is now scoped to clients in `GLOBAL_SUBSCRIBERS_ROOM` (opt-in via `subscribe_global` event) instead of broadcasting to all connected sockets
- Heartbeat changed from `io.emit` (server-wide broadcast) to per-socket individual sends, removing aggregate server state from every client's feed

Closes #25
Closes #27 
Closes #29 
Closes #30