### PR TITLE
test(contracts): add unit tests for prediction-market and market-factory

### DIFF
--- a/contracts/market-factory/src/lib.rs
+++ b/contracts/market-factory/src/lib.rs
@@ -3,7 +3,7 @@
 
 use soroban_sdk::{
     contract, contractimpl, contractmeta, contracttype, symbol_short,
-    Address, Env, String, Vec
+    Address, Env, IntoVal, String, Symbol, Vec
 };
 
 use oryn_shared::{
@@ -186,10 +186,10 @@ impl MarketFactoryContract {
             .ok_or(OrynError::InvalidInput)?;
 
         // Check permission through access control contract
-        env.invoke_contract(
+        env.invoke_contract::<()>(
             &access_control,
-            &symbol_short!("require_perm"),
-            (caller, Permission::PauseContract).into_val(&env)
+            &Symbol::new(&env, "require_perm"),
+            (caller.clone(), Permission::PauseContract).into_val(&env)
         );
 
         env.storage().persistent().set(&StorageKey::Paused, &true);
@@ -210,10 +210,10 @@ impl MarketFactoryContract {
             .ok_or(OrynError::InvalidInput)?;
 
         // Check permission through access control contract
-        env.invoke_contract(
+        env.invoke_contract::<()>(
             &access_control,
-            &symbol_short!("require_perm"),
-            (caller, Permission::PauseContract).into_val(&env)
+            &Symbol::new(&env, "require_perm"),
+            (caller.clone(), Permission::PauseContract).into_val(&env)
         );
 
         env.storage().persistent().set(&StorageKey::Paused, &false);
@@ -234,9 +234,9 @@ impl MarketFactoryContract {
             .ok_or(OrynError::InvalidInput)?;
 
         // Delegate to access control contract
-        env.invoke_contract(
+        env.invoke_contract::<()>(
             &access_control,
-            &symbol_short!("grant_role"),
+            &Symbol::new(&env, "grant_role"),
             (admin, user, role).into_val(&env)
         );
 
@@ -251,9 +251,9 @@ impl MarketFactoryContract {
             .ok_or(OrynError::InvalidInput)?;
 
         // Delegate to access control contract
-        env.invoke_contract(
+        env.invoke_contract::<()>(
             &access_control,
-            &symbol_short!("revoke_role"),
+            &Symbol::new(&env, "revoke_role"),
             (admin, user).into_val(&env)
         );
 
@@ -268,7 +268,7 @@ impl MarketFactoryContract {
             .ok_or(OrynError::InvalidInput)?;
 
         // Delegate to access control contract
-        env.invoke_contract(
+        env.invoke_contract::<()>(
             &access_control,
             &symbol_short!("blacklist"),
             (admin, user).into_val(&env)
@@ -284,5 +284,158 @@ impl MarketFactoryContract {
             return Err(OrynError::ContractPaused.into());
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        contract, contractimpl, testutils::Address as _, Address, Env, String,
+    };
+    use oryn_shared::{MarketCategory, Permission, Role};
+
+    // Stub that satisfies every cross-contract call made by MarketFactoryContract.
+    // Function names match the symbol_short! keys used in the factory.
+    #[contract]
+    struct StubAccessControl;
+
+    #[contractimpl]
+    impl StubAccessControl {
+        pub fn has_perm(_env: Env, _user: Address, _perm: Permission) -> bool {
+            true
+        }
+        pub fn require_perm(_env: Env, _caller: Address, _perm: Permission) {}
+        pub fn grant_role(_env: Env, _admin: Address, _user: Address, _role: Role) {}
+        pub fn revoke_role(_env: Env, _admin: Address, _user: Address) {}
+        pub fn blacklist(_env: Env, _admin: Address, _user: Address) {}
+    }
+
+    fn setup(env: &Env) -> (MarketFactoryContractClient, Address) {
+        let stub_id = env.register_contract(None, StubAccessControl);
+        let factory_id = env.register_contract(None, MarketFactoryContract);
+        let client = MarketFactoryContractClient::new(env, &factory_id);
+
+        let admin = Address::generate(env);
+        let config = FactoryConfig {
+            min_liquidity: 1_000_000_000_000,
+            max_market_duration: 365 * 24 * 60 * 60,
+            min_market_duration: 3600,
+            oracle_resolver: Address::generate(env),
+            treasury_contract: Address::generate(env),
+            governance_contract: Address::generate(env),
+            access_control_contract: stub_id,
+        };
+        client.initialize(&admin, &config);
+        (client, admin)
+    }
+
+    #[test]
+    fn test_initialize_starts_with_empty_market_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        assert_eq!(client.get_all_markets().len(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_double_initialize_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let stub_id = env.register_contract(None, StubAccessControl);
+        let factory_id = env.register_contract(None, MarketFactoryContract);
+        let client = MarketFactoryContractClient::new(&env, &factory_id);
+
+        let admin = Address::generate(&env);
+        let config = FactoryConfig {
+            min_liquidity: 1_000_000_000_000,
+            max_market_duration: 365 * 24 * 60 * 60,
+            min_market_duration: 3600,
+            oracle_resolver: Address::generate(&env),
+            treasury_contract: Address::generate(&env),
+            governance_contract: Address::generate(&env),
+            access_control_contract: stub_id,
+        };
+        client.initialize(&admin, &config);
+        client.initialize(&admin, &config);
+    }
+
+    #[test]
+    fn test_create_market_is_retrievable_and_increments_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let creator = Address::generate(&env);
+        let market_id = client.create_market(
+            &creator,
+            &String::from_str(&env, "Will ETH flip BTC by 2026?"),
+            &MarketCategory::Crypto,
+            &9_999_999_999u64,
+            &1_000_000_000_000i128,
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &Address::generate(&env),
+        );
+
+        assert_eq!(market_id, 1u64);
+        assert_eq!(client.get_all_markets().len(), 1);
+        assert!(client.get_market(&market_id).is_some());
+    }
+
+    #[test]
+    fn test_create_multiple_markets_sequential_ids() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let creator = Address::generate(&env);
+        for _ in 0..3 {
+            client.create_market(
+                &creator,
+                &String::from_str(&env, "Test market?"),
+                &MarketCategory::Other,
+                &9_999_999_999u64,
+                &1_000_000_000_000i128,
+                &Address::generate(&env),
+                &Address::generate(&env),
+                &Address::generate(&env),
+                &Address::generate(&env),
+            );
+        }
+
+        assert_eq!(client.get_all_markets().len(), 3);
+        assert!(client.get_market(&3u64).is_some());
+    }
+
+    #[test]
+    fn test_get_nonexistent_market_returns_none() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        assert!(client.get_market(&999u64).is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_create_market_with_insufficient_liquidity_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let creator = Address::generate(&env);
+        client.create_market(
+            &creator,
+            &String::from_str(&env, "Test?"),
+            &MarketCategory::Other,
+            &9_999_999_999u64,
+            &100i128, // below MIN_LIQUIDITY
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &Address::generate(&env),
+        );
     }
 }

--- a/contracts/prediction-market/src/lib.rs
+++ b/contracts/prediction-market/src/lib.rs
@@ -274,3 +274,229 @@ impl PredictionMarket {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use oryn_shared::{MarketCategory, MarketInfo, MarketStatus, TokenType};
+
+    fn make_market(env: &Env, oracle: &Address) -> MarketInfo {
+        MarketInfo {
+            market_id: String::from_str(env, "mkt-1"),
+            question: String::from_str(env, "Will BTC hit 100k?"),
+            category: MarketCategory::Crypto,
+            creator: Address::generate(env),
+            yes_token_id: Address::generate(env),
+            no_token_id: Address::generate(env),
+            pool_address: Address::generate(env),
+            oracle_address: oracle.clone(),
+            created_at: 0,
+            expires_at: 9_999_999_999,
+            resolution_criteria: String::from_str(env, "Price feed"),
+            status: MarketStatus::Active,
+            total_volume: 0,
+            total_liquidity: 1_000_000_000_000,
+            outcome: None,
+            min_liquidity: 1_000_000_000_000,
+        }
+    }
+
+    #[test]
+    fn test_initialize_stores_market_info() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        let m = client.get_market();
+        assert_eq!(m.question, String::from_str(&env, "Will BTC hit 100k?"));
+        assert_eq!(m.status, MarketStatus::Active);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_double_initialize_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let market = make_market(&env, &oracle);
+        client.initialize(&admin, &oracle, &market);
+        client.initialize(&admin, &oracle, &market);
+    }
+
+    #[test]
+    fn test_buy_yes_tokens_increases_position() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        client.buy(&user, &TokenType::Yes, &1_000_000_000, &500_000_000);
+
+        let pos = client.get_position(&user);
+        assert_eq!(pos.yes_tokens, 1_000_000_000);
+        assert_eq!(pos.no_tokens, 0);
+    }
+
+    #[test]
+    fn test_buy_no_tokens_increases_position() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        client.buy(&user, &TokenType::No, &2_000_000_000, &500_000_000);
+
+        let pos = client.get_position(&user);
+        assert_eq!(pos.no_tokens, 2_000_000_000);
+        assert_eq!(pos.yes_tokens, 0);
+    }
+
+    #[test]
+    fn test_sell_reduces_position_and_records_pnl() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        client.buy(&user, &TokenType::Yes, &3_000_000_000, &500_000_000);
+        client.sell(&user, &TokenType::Yes, &1_000_000_000, &600_000_000);
+
+        let pos = client.get_position(&user);
+        assert_eq!(pos.yes_tokens, 2_000_000_000);
+        assert!(pos.realized_pnl > 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sell_exceeds_balance_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        client.buy(&user, &TokenType::Yes, &500_000_000, &500_000_000);
+        client.sell(&user, &TokenType::Yes, &1_000_000_000, &500_000_000);
+    }
+
+    #[test]
+    fn test_resolve_by_oracle_sets_outcome() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        client.resolve(&oracle, &true);
+
+        let m = client.get_market();
+        assert_eq!(m.status, MarketStatus::Resolved);
+        assert_eq!(m.outcome, Some(true));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_resolve_unauthorized_oracle_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        let fake = Address::generate(&env);
+        client.resolve(&fake, &true);
+    }
+
+    #[test]
+    fn test_claim_yes_winner_returns_tokens() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        let amount = 2_000_000_000i128;
+        client.buy(&user, &TokenType::Yes, &amount, &500_000_000);
+        client.resolve(&oracle, &true);
+
+        let winnings = client.claim(&user);
+        assert_eq!(winnings, amount);
+    }
+
+    #[test]
+    fn test_claim_losing_side_returns_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let loser = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        client.buy(&loser, &TokenType::No, &1_000_000_000, &500_000_000);
+        client.resolve(&oracle, &true); // YES wins; loser holds NO
+
+        let winnings = client.claim(&loser);
+        assert_eq!(winnings, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_claim_twice_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin, &oracle, &make_market(&env, &oracle));
+
+        client.buy(&user, &TokenType::Yes, &1_000_000_000, &500_000_000);
+        client.resolve(&oracle, &true);
+        client.claim(&user);
+        client.claim(&user);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 11 unit tests to `prediction-market` contract covering `initialize`, `buy` (YES/NO), `sell` with PnL tracking, sell-exceeds-balance guard, `resolve` by oracle, unauthorized-oracle guard, `claim` winner, claim losing side, and double-claim guard
- Adds 6 unit tests to `market-factory` contract covering `initialize`, double-init guard, `create_market` with sequential IDs, multiple market creation, nonexistent-market lookup, and insufficient-liquidity guard
- Includes a `StubAccessControl` contract in the market-factory test module to satisfy cross-contract permission checks without a full deployment
- Fixes pre-existing compile errors that only surface under the `testutils` feature: missing `IntoVal`/`Symbol` imports, `symbol_short!` calls exceeding the 9-char limit replaced with `Symbol::new`, missing `::<()>` type annotations on void `invoke_contract` calls, and a borrow-after-move on `caller`
- Pins `derive_arbitrary` to `1.3.2` in the lock file to match `soroban-env-common`'s exact `arbitrary = "=1.3.2"` requirement (pre-existing version mismatch that prevented test compilation)

## Test plan

- [ ] `cargo test -p prediction-market` — 11 tests pass
- [ ] `cargo test -p market-factory` — 6 tests pass
- [ ] `cargo build --release` for both contracts still succeeds

Closes #48