### PR TITLE
test(contracts): add unit tests for amm-pool buy/sell flows

### DIFF
--- a/contracts/amm-pool/src/lib.rs
+++ b/contracts/amm-pool/src/lib.rs
@@ -138,7 +138,7 @@ impl AmmPoolContract {
         Self::set_reserves(&env, yes_reserve + yes_amt, no_reserve + no_amt)?;
         Self::mint_lp(&env, &provider, lp_mint)?;
 
-        let pool_id = Self::get_pool_info(&env).pool_id.clone();
+        let pool_id = Self::get_pool_info_internal(&env).pool_id.clone();
 
         env.events().publish(
             (symbol_short!("liq"), symbol_short!("add")),
@@ -176,7 +176,7 @@ impl AmmPoolContract {
 
         Self::set_reserves(&env, result.new_yes_reserve, result.new_no_reserve)?;
 
-        let pool_id = Self::get_pool_info(&env).pool_id.clone();
+        let pool_id = Self::get_pool_info_internal(&env).pool_id.clone();
         let token_in_clone = token_in.clone();
 
         env.events().publish(
@@ -199,6 +199,22 @@ impl AmmPoolContract {
         );
 
         Ok(result.amount_out)
+    }
+
+    // --------------------------------------------------
+    // GETTERS
+    // --------------------------------------------------
+
+    pub fn get_pool_info(env: Env) -> PoolInfo {
+        Self::get_pool_info_internal(&env)
+    }
+
+    pub fn get_yes_reserve_pub(env: Env) -> i128 {
+        Self::get_yes_reserve(&env)
+    }
+
+    pub fn get_no_reserve_pub(env: Env) -> i128 {
+        Self::get_no_reserve(&env)
     }
 
     // --------------------------------------------------
@@ -297,7 +313,7 @@ impl AmmPoolContract {
             .unwrap_or(30)
     }
 
-    fn get_pool_info(env: &Env) -> PoolInfo {
+    fn get_pool_info_internal(env: &Env) -> PoolInfo {
         env.storage()
             .persistent()
             .get(&StorageKey::PoolInfo)
@@ -328,5 +344,200 @@ impl AmmPoolContract {
             .persistent()
             .set(&StorageKey::TotalLpTokens, &total);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use oryn_shared::TokenType;
+
+    fn setup(env: &Env, fee_rate: u32) -> (AmmPoolContractClient, Address) {
+        let factory = Address::generate(env);
+        let market = Address::generate(env);
+        let admin = Address::generate(env);
+        let contract_id = env.register_contract(None, AmmPoolContract);
+        let client = AmmPoolContractClient::new(env, &contract_id);
+
+        client.initialize(
+            &factory,
+            &market,
+            &admin,
+            &String::from_str(env, "pool-1"),
+            &Address::generate(env),
+            &Address::generate(env),
+            &Address::generate(env),
+            &Address::generate(env),
+            &fee_rate,
+        );
+
+        (client, admin)
+    }
+
+    #[test]
+    fn test_initialize_creates_empty_pool() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env, 30);
+
+        let info = client.get_pool_info();
+        assert_eq!(info.yes_reserve, 0);
+        assert_eq!(info.no_reserve, 0);
+        assert_eq!(info.fee_rate, 30);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_double_initialize_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let factory = Address::generate(&env);
+        let contract_id = env.register_contract(None, AmmPoolContract);
+        let client = AmmPoolContractClient::new(&env, &contract_id);
+        let args = (
+            factory.clone(),
+            Address::generate(&env),
+            Address::generate(&env),
+            String::from_str(&env, "pool-1"),
+            Address::generate(&env),
+            Address::generate(&env),
+            Address::generate(&env),
+            Address::generate(&env),
+            30u32,
+        );
+        client.initialize(
+            &args.0, &args.1, &args.2, &args.3, &args.4, &args.5, &args.6, &args.7, &args.8,
+        );
+        client.initialize(
+            &factory,
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &String::from_str(&env, "pool-1"),
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &Address::generate(&env),
+            &30u32,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_initialize_fee_above_max_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        setup(&env, 10_001); // above MAX_FEE_RATE
+    }
+
+    #[test]
+    fn test_add_initial_liquidity_splits_evenly_and_mints_lp() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env, 30);
+
+        let provider = Address::generate(&env);
+        let usdc = 2_000_000_000i128;
+        let lp = client.add_liquidity(&provider, &usdc);
+
+        assert_eq!(lp, usdc);
+        // Reserves are stored separately from PoolInfo — use the dedicated getters
+        assert_eq!(client.get_yes_reserve_pub(), usdc / 2);
+        assert_eq!(client.get_no_reserve_pub(), usdc / 2);
+    }
+
+    #[test]
+    fn test_add_proportional_liquidity_after_first_deposit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env, 30);
+
+        let p1 = Address::generate(&env);
+        let p2 = Address::generate(&env);
+
+        client.add_liquidity(&p1, &2_000_000_000);
+        let lp2 = client.add_liquidity(&p2, &1_000_000_000);
+
+        assert!(lp2 > 0);
+        assert!(lp2 < 2_000_000_000); // proportional share, not equal to first deposit
+    }
+
+    #[test]
+    fn test_swap_yes_for_no_returns_positive_output() {
+        let env = Env::default();
+        env.mock_all_auths();
+        // Use 2B reserves so that a 10M swap (~0.5%) stays under MAX_SLIPPAGE_BPS (5%)
+        let (client, _) = setup(&env, 30);
+
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &2_000_000_000);
+
+        let trader = Address::generate(&env);
+        let amount_in = 10_000_000i128;
+        let out = client.swap(&trader, &TokenType::Yes, &amount_in, &0);
+
+        assert!(out > 0);
+        assert!(out < amount_in); // fee + slippage means output is always less than input
+    }
+
+    #[test]
+    fn test_swap_no_for_yes_returns_positive_output() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env, 30);
+
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &2_000_000_000);
+
+        let trader = Address::generate(&env);
+        let out = client.swap(&trader, &TokenType::No, &10_000_000, &0);
+
+        assert!(out > 0);
+    }
+
+    #[test]
+    fn test_swap_updates_reserves_correctly() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env, 30);
+
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &2_000_000_000);
+
+        let yes_before = client.get_yes_reserve_pub();
+        let no_before = client.get_no_reserve_pub();
+
+        let trader = Address::generate(&env);
+        client.swap(&trader, &TokenType::Yes, &10_000_000, &0);
+
+        // YES reserve increases, NO reserve decreases after a YES→NO swap
+        assert!(client.get_yes_reserve_pub() > yes_before);
+        assert!(client.get_no_reserve_pub() < no_before);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_swap_min_out_not_met_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env, 30);
+
+        let provider = Address::generate(&env);
+        client.add_liquidity(&provider, &2_000_000_000);
+
+        let trader = Address::generate(&env);
+        // With 10M in and ~9.87M expected out, demanding 15M should fail
+        client.swap(&trader, &TokenType::Yes, &10_000_000, &15_000_000);
+    }
+
+    #[test]
+    fn test_get_pool_info_returns_fee_rate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env, 50);
+
+        let info = client.get_pool_info();
+        assert_eq!(info.fee_rate, 50);
+        assert_eq!(info.total_fees_collected, 0);
     }
 }


### PR DESCRIPTION
## Summary

- Adds 10 unit tests to the `amm-pool` Soroban contract covering the full liquidity and swap lifecycle
- Tests include: empty pool after initialize, double-init guard, fee-above-max guard, initial 50/50 liquidity split with correct LP minting, proportional secondary liquidity, YES→NO swap with positive output and correct reserve updates, NO→YES symmetric swap, and min_out slippage guard
- Adds three public getter functions (`get_pool_info`, `get_yes_reserve_pub`, `get_no_reserve_pub`) needed for testing — `PoolInfo.yes_reserve` is stale after `initialize` because `add_liquidity` writes reserves to separate storage keys
- Test swap amounts (10M against 1B reserves = ~0.5% depth) are chosen to stay within the contract's `MAX_SLIPPAGE_BPS` (500 bps = 5%) hard cap

## Test plan

- [ ] `cargo test -p amm-pool` — 10 tests pass
- [ ] `cargo build --release -p amm-pool` still succeeds

Closes #49