### PR TITLE
feat: handle partial order execution (#60)

### DIFF
--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -5,7 +5,7 @@ const logger = require('../config/logger');
 const { NotFoundError, ValidationError, StellarError } = require('../middleware/errorHandler');
 
 class TradeController {
-  // Execute a trade
+  // Execute a trade with partial fill support
   static async executeTrade(req, res) {
     const {
       marketId,
@@ -39,24 +39,21 @@ class TradeController {
     try {
       // Calculate expected price and slippage
       let expectedPrice, priceImpact, fees;
-      
+
       if (market.metadata?.contractAddress) {
-        // Use Soroban contract for price calculation
         const priceCalculation = await sorobanService.calculateTradePrice(
           market.metadata.contractAddress,
           tokenType,
           tradeType,
           amount
         );
-        
         expectedPrice = priceCalculation.price;
         priceImpact = priceCalculation.priceImpact;
         fees = priceCalculation.fees;
       } else {
-        // Fallback to basic AMM calculation
         expectedPrice = tokenType === 'yes' ? market.currentYesPrice : market.currentNoPrice;
-        priceImpact = 0.01; // 1% default
-        fees = amount * 0.005; // 0.5% platform fee
+        priceImpact = 0.01;
+        fees = amount * 0.005;
       }
 
       // Check slippage tolerance
@@ -64,7 +61,21 @@ class TradeController {
         throw new ValidationError(`Price impact ${(priceImpact * 100).toFixed(2)}% exceeds maximum slippage ${(maxSlippage * 100).toFixed(2)}%`);
       }
 
-      const totalCost = tradeType === 'buy' ? amount * expectedPrice : amount;
+      // --- Partial fill calculation ---
+      // Available liquidity is the opposite-side reserve (what can be matched)
+      const availableLiquidity = tokenType === 'yes'
+        ? (market.noLiquidity || market.liquidity * (1 - market.currentYesPrice))
+        : (market.yesLiquidity || market.liquidity * market.currentYesPrice);
+
+      // Max fillable amount given current liquidity (cap at 30% of available to avoid draining)
+      const maxFillable = availableLiquidity * 0.3;
+      const filledAmount = Math.min(amount, maxFillable > 0 ? maxFillable : amount);
+      const remainingAmount = parseFloat((amount - filledAmount).toFixed(7));
+      const isPartial = remainingAmount > 0.000001; // threshold to avoid float noise
+      const fillRatio = filledAmount / amount;
+
+      const effectiveAmount = filledAmount;
+      const totalCost = tradeType === 'buy' ? effectiveAmount * expectedPrice : effectiveAmount;
       const platformFee = totalCost * (market.platformFee || 0.005);
 
       // Create trade record
@@ -74,7 +85,7 @@ class TradeController {
         userWalletAddress: req.user.walletAddress,
         tradeType,
         tokenType,
-        amount,
+        amount: effectiveAmount,
         price: expectedPrice,
         totalCost,
         fees: {
@@ -90,6 +101,12 @@ class TradeController {
           yesPriceBefore: market.currentYesPrice,
           noPriceBefore: market.currentNoPrice
         },
+        partialFill: {
+          isPartial,
+          filledAmount,
+          remainingAmount,
+          fillRatio
+        },
         status: 'pending'
       });
 
@@ -97,50 +114,44 @@ class TradeController {
 
       // Execute trade on Stellar/Soroban
       let stellarResult;
-      
+
       if (market.metadata?.contractAddress) {
-        // Execute via Soroban contract
         stellarResult = await sorobanService.executeTrade(
-          // In real implementation, you'd get user's keypair securely
-          stellarService.adminKeypair, // Placeholder
+          stellarService.adminKeypair,
           market.metadata.contractAddress,
           {
             tokenType,
             tradeType,
-            amount,
+            amount: effectiveAmount,
             maxSlippage,
-            deadline: Math.floor(Date.now() / 1000) + 300 // 5 minutes
+            deadline: Math.floor(Date.now() / 1000) + 300
           }
         );
       } else {
-        // Execute via traditional Stellar DEX
-        const asset = tokenType === 'yes' 
+        const asset = tokenType === 'yes'
           ? new stellarService.Asset(market.yesTokenAssetCode, market.yesTokenIssuer)
           : new stellarService.Asset(market.noTokenAssetCode, market.noTokenIssuer);
 
         stellarResult = await stellarService.placeOrder(
-          stellarService.adminKeypair, // Placeholder
+          stellarService.adminKeypair,
           tradeType === 'buy' ? stellarService.Asset.native() : asset,
           tradeType === 'buy' ? asset : stellarService.Asset.native(),
-          amount,
+          effectiveAmount,
           expectedPrice
         );
       }
 
-      // Update trade with Stellar transaction hash
       trade.stellarTransactionHash = stellarResult.hash || stellarResult.transactionHash;
-      trade.status = 'confirmed';
-      
-      // Update market prices after trade
-      const newYesPrice = tokenType === 'yes' && tradeType === 'buy' 
-        ? Math.min(0.99, market.currentYesPrice + priceImpact)
+      trade.status = isPartial ? 'partially_filled' : 'confirmed';
+
+      const newYesPrice = tokenType === 'yes' && tradeType === 'buy'
+        ? Math.min(0.99, market.currentYesPrice + priceImpact * fillRatio)
         : market.currentYesPrice;
-      
       const newNoPrice = 1.0 - newYesPrice;
-      
+
       market.updatePrices(newYesPrice, newNoPrice);
       market.addTrade(totalCost);
-      
+
       trade.marketPrices.yesPriceAfter = newYesPrice;
       trade.marketPrices.noPriceAfter = newNoPrice;
 
@@ -168,7 +179,6 @@ class TradeController {
       position.addTrade(trade);
       await position.save();
 
-      // Update user stats
       const user = await User.findOne({ walletAddress: req.user.walletAddress });
       if (user) {
         user.updateStats(trade);
@@ -181,10 +191,17 @@ class TradeController {
         user: req.user.walletAddress,
         tokenType,
         tradeType,
-        amount,
+        requestedAmount: amount,
+        filledAmount,
+        remainingAmount,
+        isPartial,
         price: expectedPrice,
         txHash: stellarResult.hash || stellarResult.transactionHash
       });
+
+      const message = isPartial
+        ? `Order partially filled: ${filledAmount.toFixed(4)} of ${amount} filled. ${remainingAmount.toFixed(4)} remaining due to insufficient liquidity.`
+        : 'Trade executed successfully';
 
       res.status(201).json({
         success: true,
@@ -194,12 +211,17 @@ class TradeController {
             marketId,
             tokenType,
             tradeType,
-            amount,
+            requestedAmount: amount,
+            filledAmount,
+            remainingAmount,
+            isPartial,
+            fillRatio,
             executedPrice: expectedPrice,
             totalCost,
             fees: trade.fees,
             slippage: priceImpact,
             transactionHash: trade.stellarTransactionHash,
+            status: trade.status,
             timestamp: trade.timestamp
           },
           newMarketPrices: {
@@ -212,20 +234,13 @@ class TradeController {
             unrealizedPnL: position.unrealizedPnL
           }
         },
-        message: 'Trade executed successfully'
+        message
       });
     } catch (error) {
-      // Update trade status to failed if it was created
-      if (Trade.findOne({ tradeId })) {
-        await Trade.updateOne(
-          { tradeId },
-          { 
-            status: 'failed',
-            'metadata.failureReason': error.message
-          }
-        );
-      }
-
+      await Trade.updateOne(
+        { tradeId },
+        { status: 'failed', 'metadata.failureReason': error.message }
+      );
       logger.error('Trade execution failed:', error);
       throw new StellarError(`Trade execution failed: ${error.message}`);
     }

--- a/backend/src/models/Trade.js
+++ b/backend/src/models/Trade.js
@@ -77,7 +77,7 @@ const tradeSchema = new mongoose.Schema({
   }],
   status: {
     type: String,
-    enum: ['pending', 'confirmed', 'failed', 'cancelled'],
+    enum: ['pending', 'confirmed', 'partially_filled', 'failed', 'cancelled'],
     default: 'pending',
     index: true
   },
@@ -125,6 +125,12 @@ const tradeSchema = new mongoose.Schema({
       default: 0,
       min: 0
     }
+  },
+  partialFill: {
+    isPartial: { type: Boolean, default: false },
+    filledAmount: { type: Number, default: 0, min: 0 },
+    remainingAmount: { type: Number, default: 0, min: 0 },
+    fillRatio: { type: Number, default: 1, min: 0, max: 1 }
   },
   metadata: {
     userAgent: String,

--- a/frontend/src/components/ui/ConfirmationModal.tsx
+++ b/frontend/src/components/ui/ConfirmationModal.tsx
@@ -8,7 +8,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Info, AlertCircle } from "lucide-react";
+import { Info, AlertCircle, AlertTriangle } from "lucide-react";
 
 interface ConfirmationModalProps {
   isOpen: boolean;
@@ -25,6 +25,60 @@ interface ConfirmationModalProps {
     fee: string;
     slippage: string;
   };
+}
+
+export interface PartialFillResult {
+  isPartial: boolean;
+  filledAmount: number;
+  remainingAmount: number;
+  fillRatio: number;
+  requestedAmount: number;
+}
+
+interface PartialFillBannerProps {
+  result: PartialFillResult;
+  tokenType: 'YES' | 'NO';
+}
+
+export function PartialFillBanner({ result, tokenType }: PartialFillBannerProps) {
+  const fillPct = (result.fillRatio * 100).toFixed(1);
+  return (
+    <div className="p-3 rounded-lg bg-warning/10 border border-warning/20 space-y-2">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="w-4 h-4 text-warning shrink-0" />
+        <p className="text-xs font-semibold text-warning">Partial Fill — Insufficient Liquidity</p>
+      </div>
+      <div className="grid grid-cols-3 gap-2 text-xs">
+        <div className="text-center p-2 rounded bg-white/5">
+          <p className="text-white/50 mb-0.5">Requested</p>
+          <p className="font-bold">{result.requestedAmount.toFixed(4)}</p>
+        </div>
+        <div className="text-center p-2 rounded bg-success/10 border border-success/20">
+          <p className="text-success/70 mb-0.5">Filled</p>
+          <p className="font-bold text-success">{result.filledAmount.toFixed(4)}</p>
+        </div>
+        <div className="text-center p-2 rounded bg-warning/10 border border-warning/20">
+          <p className="text-warning/70 mb-0.5">Remaining</p>
+          <p className="font-bold text-warning">{result.remainingAmount.toFixed(4)}</p>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <div className="flex justify-between text-xs text-white/50">
+          <span>Fill progress</span>
+          <span>{fillPct}%</span>
+        </div>
+        <div className="w-full h-1.5 rounded-full bg-white/10 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-warning to-success transition-all duration-500"
+            style={{ width: `${fillPct}%` }}
+          />
+        </div>
+      </div>
+      <p className="text-[10px] text-white/40">
+        {result.remainingAmount.toFixed(4)} {tokenType} tokens remain unfilled. Add liquidity or retry later.
+      </p>
+    </div>
+  );
 }
 
 export function TradeConfirmationModal({
@@ -104,6 +158,13 @@ export function TradeConfirmationModal({
               </p>
             </div>
           )}
+
+          <div className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 flex gap-2 items-start">
+            <Info className="w-4 h-4 text-blue-400 shrink-0 mt-0.5" />
+            <p className="text-xs text-blue-300/80">
+              Large orders may be partially filled if liquidity is insufficient. Any unfilled portion will not be charged.
+            </p>
+          </div>
         </div>
 
         <DialogFooter className="gap-2 sm:gap-0">

--- a/frontend/src/pages/MarketDetail.tsx
+++ b/frontend/src/pages/MarketDetail.tsx
@@ -11,7 +11,7 @@ import { apiService } from '@/services/apiService';
 import { useWallet } from '@/contexts/WalletContext';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { toast } from 'sonner';
-import { TradeConfirmationModal } from '@/components/ui/ConfirmationModal';
+import { TradeConfirmationModal, PartialFillBanner, PartialFillResult } from '@/components/ui/ConfirmationModal';
 import { CountdownTimer } from '@/components/ui/CountdownTimer';
 import { ResolutionPanel } from '@/components/ResolutionPanel';
 
@@ -29,6 +29,7 @@ export default function MarketDetail() {
   const [amount, setAmount] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [partialFillResult, setPartialFillResult] = useState<PartialFillResult | null>(null);
   const [txProgress, setTxProgress] = useState<{
     phase: 'idle' | 'building' | 'signing' | 'submitting' | 'confirming' | 'success' | 'error';
     message: string;
@@ -150,6 +151,7 @@ export default function MarketDetail() {
       toast.error('Please enter a valid amount');
       return;
     }
+    setPartialFillResult(null);
     setIsConfirmModalOpen(true);
   };
 
@@ -161,6 +163,7 @@ export default function MarketDetail() {
     }
 
     setIsLoading(true);
+    setPartialFillResult(null);
 
     const pollTransaction = async (txHash: string) => {
       const maxAttempts = 12;
@@ -178,24 +181,23 @@ export default function MarketDetail() {
 
       throw new Error('Transaction confirmation timed out');
     };
-    
+
     try {
       setTxProgress({ phase: 'building', message: 'Building transaction...' });
       toast.loading('Building transaction...', { id: 'trade-toast' });
 
-      // Build transaction using backend API
       const transactionData = tradeType === 'buy'
         ? await apiService.transactions.buildBuyTokens({
             marketId: currentMarket.id,
             tokenType: position.toLowerCase() as 'yes' | 'no',
             amount: parseFloat(amount),
-            maxSlippage: 1.0 // 1% slippage tolerance
+            maxSlippage: 1.0
           }, publicKey)
         : await apiService.transactions.buildSellTokens({
             marketId: currentMarket.id,
             tokenType: position.toLowerCase() as 'yes' | 'no',
             amount: parseFloat(amount),
-            maxSlippage: 1.0 // 1% slippage tolerance
+            maxSlippage: 1.0
           }, publicKey);
 
       if (!transactionData?.xdr) {
@@ -210,9 +212,7 @@ export default function MarketDetail() {
       setTxProgress({ phase: 'submitting', message: 'Submitting transaction to network...' });
       toast.loading('Submitting transaction to network...', { id: 'trade-toast' });
 
-      const submitResult = await apiService.transactions.submitSignedTransaction({
-        signedXdr
-      });
+      const submitResult = await apiService.transactions.submitSignedTransaction({ signedXdr });
 
       const txHash = submitResult?.transactionHash;
       if (!txHash) {
@@ -220,13 +220,31 @@ export default function MarketDetail() {
       }
 
       setTxProgress({ phase: 'confirming', message: 'Confirming transaction...', txHash });
-      await pollTransaction(txHash);
+      const confirmed = await pollTransaction(txHash);
 
-      setTxProgress({ phase: 'success', message: 'Transaction confirmed', txHash });
-      toast.success(`${tradeType.charAt(0).toUpperCase() + tradeType.slice(1)} order successful!`, {
-        id: 'trade-toast',
-        description: `${tradeType === 'buy' ? 'Bought' : 'Sold'} ${tokensReceived} ${position} tokens`
-      });
+      // Handle partial fill from response
+      const tradeData = confirmed?.data?.trade ?? submitResult?.data?.trade;
+      if (tradeData?.isPartial) {
+        const pfResult: PartialFillResult = {
+          isPartial: true,
+          filledAmount: tradeData.filledAmount,
+          remainingAmount: tradeData.remainingAmount,
+          fillRatio: tradeData.fillRatio,
+          requestedAmount: tradeData.requestedAmount ?? parseFloat(amount),
+        };
+        setPartialFillResult(pfResult);
+        setTxProgress({ phase: 'success', message: 'Order partially filled', txHash });
+        toast.warning(
+          `Partial fill: ${tradeData.filledAmount.toFixed(4)} of ${parseFloat(amount).toFixed(4)} ${position} filled`,
+          { id: 'trade-toast', description: `${tradeData.remainingAmount.toFixed(4)} remaining — insufficient liquidity` }
+        );
+      } else {
+        setTxProgress({ phase: 'success', message: 'Transaction confirmed', txHash });
+        toast.success(`${tradeType.charAt(0).toUpperCase() + tradeType.slice(1)} order successful!`, {
+          id: 'trade-toast',
+          description: `${tradeType === 'buy' ? 'Bought' : 'Sold'} ${tokensReceived} ${position} tokens`
+        });
+      }
 
       setAmount('');
     } catch (error) {
@@ -398,6 +416,30 @@ export default function MarketDetail() {
                       <span className="text-muted-foreground">Est. price impact</span>
                       <span className="text-warning">{priceImpact}%</span>
                     </div>
+                    <div className="flex justify-between text-sm">
+                      <span className="text-muted-foreground">Est. fee</span>
+                      <span>{estimatedFee} USDC</span>
+                    </div>
+                    {partialFillResult && (
+                      <>
+                        <div className="border-t border-border/50 pt-2 mt-1" />
+                        <div className="flex justify-between text-sm">
+                          <span className="text-success">Filled</span>
+                          <span className="font-medium text-success">{partialFillResult.filledAmount.toFixed(4)} {position}</span>
+                        </div>
+                        <div className="flex justify-between text-sm">
+                          <span className="text-warning">Remaining</span>
+                          <span className="font-medium text-warning">{partialFillResult.remainingAmount.toFixed(4)} {position}</span>
+                        </div>
+                        <div className="w-full h-1.5 rounded-full bg-white/10 overflow-hidden mt-1">
+                          <div
+                            className="h-full rounded-full bg-gradient-to-r from-warning to-success"
+                            style={{ width: `${(partialFillResult.fillRatio * 100).toFixed(1)}%` }}
+                          />
+                        </div>
+                      </>
+                    )}
+                  </div>
                   </div>
 
                   {/* Trade Button */}
@@ -443,6 +485,10 @@ export default function MarketDetail() {
                         <p className="text-[10px] text-muted-foreground mt-2 break-all">Hash: {txProgress.txHash}</p>
                       )}
                     </div>
+                  )}
+
+                  {partialFillResult && (
+                    <PartialFillBanner result={partialFillResult} tokenType={position} />
                   )}
                 </TabsContent>
 


### PR DESCRIPTION
- Add partialFill schema to Trade model (filledAmount, remainingAmount, fillRatio, isPartial)
- Add 'partially_filled' to Trade status enum
- Compute fillable amount against available liquidity in executeTrade controller
- Return filled/remaining quantities and fillRatio in trade response
- Add PartialFillBanner component with progress bar (filled vs remaining)
- Show partial fill info in trade summary panel (live update after execution)
- Inform users of partial fill risk in TradeConfirmationModal
- Toast warning with exact filled/remaining amounts on partial execution

Closes #60 