### PR TITLE
feat: add offline mode handling with graceful degradation (#62)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,36 +20,48 @@ import SmoothScroll from "@/components/SmoothScroll";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import IntegrationTest from "./components/IntegrationTest";
 import { RabetWalletTest } from "./components/RabetWalletTest";
+import { OfflineBanner } from "@/components/OfflineBanner";
+import { useOffline } from "@/hooks/useOffline";
 
 const queryClient = new QueryClient();
+
+function AppShell() {
+  const isOffline = useOffline();
+  return (
+    <>
+      {isOffline && <OfflineBanner />}
+      <Toaster />
+      <Sonner />
+      <HotToaster />
+      <SmoothScroll />
+      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/landingpage" element={<LandingPage />} />
+          <Route path="/markets" element={<Markets />} />
+          <Route path="/market/:id" element={<MarketDetail />} />
+          <Route path="/create" element={<CreateMarket />} />
+          <Route path="/leaderboard" element={<Leaderboard />} />
+          <Route path="/portfolio" element={<Portfolio />} />
+          <Route path="/analytics" element={<Analytics />} />
+          <Route path="/governance" element={<Governance />} />
+          <Route path="/how-it-works" element={<HowItWorks />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/integration-test" element={<IntegrationTest />} />
+          <Route path="/rabet-test" element={<RabetWalletTest />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </BrowserRouter>
+    </>
+  );
+}
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <WalletProvider>
       <WebSocketProvider>
         <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <HotToaster />
-          <SmoothScroll />
-          <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-            <Routes>
-              <Route path="/" element={<LandingPage />} />
-              <Route path="/landingpage" element={<LandingPage />} />
-              <Route path="/markets" element={<Markets />} />
-              <Route path="/market/:id" element={<MarketDetail />} />
-              <Route path="/create" element={<CreateMarket />} />
-              <Route path="/leaderboard" element={<Leaderboard />} />
-              <Route path="/portfolio" element={<Portfolio />} />
-              <Route path="/analytics" element={<Analytics />} />
-              <Route path="/governance" element={<Governance />} />
-              <Route path="/how-it-works" element={<HowItWorks />} />
-              <Route path="/about" element={<About />} />
-              <Route path="/integration-test" element={<IntegrationTest />} />
-              <Route path="/rabet-test" element={<RabetWalletTest />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
+          <AppShell />
         </TooltipProvider>
       </WebSocketProvider>
     </WalletProvider>

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,10 @@
+import { WifiOff } from 'lucide-react';
+
+export function OfflineBanner() {
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[100] flex items-center justify-center gap-2 bg-destructive/90 backdrop-blur-sm px-4 py-2 text-white text-sm font-medium shadow-lg">
+      <WifiOff className="w-4 h-4 shrink-0" />
+      <span>You're offline — showing cached data. Trading is disabled until connection is restored.</span>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useOffline.ts
+++ b/frontend/src/hooks/useOffline.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+export function useOffline() {
+  const [isOffline, setIsOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const goOffline = () => setIsOffline(true);
+    const goOnline = () => setIsOffline(false);
+
+    window.addEventListener('offline', goOffline);
+    window.addEventListener('online', goOnline);
+
+    return () => {
+      window.removeEventListener('offline', goOffline);
+      window.removeEventListener('online', goOnline);
+    };
+  }, []);
+
+  return isOffline;
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -22,39 +22,75 @@ class ApiClient {
     delete this.defaultHeaders['Authorization'];
   }
 
+  private cacheKey(endpoint: string) {
+    return `oryn_cache:${endpoint}`;
+  }
+
+  private writeCache(endpoint: string, data: unknown) {
+    try {
+      localStorage.setItem(this.cacheKey(endpoint), JSON.stringify({ data, ts: Date.now() }));
+    } catch { /* storage full — ignore */ }
+  }
+
+  private readCache<T>(endpoint: string): ApiResponse<T> | null {
+    try {
+      const raw = localStorage.getItem(this.cacheKey(endpoint));
+      if (!raw) return null;
+      const { data } = JSON.parse(raw);
+      return { ...(data as ApiResponse<T>), cached: true } as ApiResponse<T> & { cached: boolean };
+    } catch {
+      return null;
+    }
+  }
+
   // Generic request method
   private async request<T>(
     endpoint: string,
     options: RequestInit = {}
   ): Promise<ApiResponse<T>> {
+    const isGet = !options.method || options.method === 'GET';
+
+    // Serve from cache immediately when offline
+    if (!navigator.onLine) {
+      if (isGet) {
+        const cached = this.readCache<T>(endpoint);
+        if (cached) return cached;
+      }
+      throw new Error('You are offline. Please check your network connection.');
+    }
+
     const url = `${this.baseURL}${endpoint}`;
-    
     const config: RequestInit = {
       ...options,
-      headers: {
-        ...this.defaultHeaders,
-        ...options.headers,
-      },
+      headers: { ...this.defaultHeaders, ...options.headers },
       signal: AbortSignal.timeout(this.timeout),
     };
 
     try {
       const response = await fetch(url, config);
-      
+
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
         throw new Error(errorData.message || `HTTP ${response.status}: ${response.statusText}`);
       }
 
-      const data = await response.json();
+      const data: ApiResponse<T> = await response.json();
+
+      // Cache successful GET responses
+      if (isGet && data.success) {
+        this.writeCache(endpoint, data);
+      }
+
       return data;
     } catch (error) {
-      console.error(`API Request failed: ${endpoint}`, error);
-      
-      if (error instanceof Error) {
-        throw new Error(`API Error: ${error.message}`);
+      // Network failure — fall back to cache for GETs
+      if (isGet) {
+        const cached = this.readCache<T>(endpoint);
+        if (cached) return cached;
       }
-      
+
+      console.error(`API Request failed: ${endpoint}`, error);
+      if (error instanceof Error) throw new Error(`API Error: ${error.message}`);
       throw new Error('Unknown API error occurred');
     }
   }

--- a/frontend/src/pages/MarketDetail.tsx
+++ b/frontend/src/pages/MarketDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft, TrendingUp, Users, Calendar, Clock, ExternalLink, Info, Loader2, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, TrendingUp, Users, Calendar, Clock, ExternalLink, Info, Loader2, AlertTriangle, WifiOff } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -14,6 +14,7 @@ import { toast } from 'sonner';
 import { TradeConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { CountdownTimer } from '@/components/ui/CountdownTimer';
 import { ResolutionPanel } from '@/components/ResolutionPanel';
+import { useOffline } from '@/hooks/useOffline';
 
 function formatVolume(volume: number): string {
   if (volume >= 1000000) return `$${(volume / 1000000).toFixed(2)}M`;
@@ -24,6 +25,7 @@ function formatVolume(volume: number): string {
 export default function MarketDetail() {
   const { id } = useParams();
   const { isConnected, connect, publicKey, signTransaction } = useWallet();
+  const isOffline = useOffline();
   const [tradeType, setTradeType] = useState<'buy' | 'sell'>('buy');
   const [position, setPosition] = useState<'YES' | 'NO'>('YES');
   const [amount, setAmount] = useState('');
@@ -142,6 +144,10 @@ export default function MarketDetail() {
   const estimatedFee = amount ? (parseFloat(amount) * 0.005).toFixed(4) : '0';
 
   const handleTradeStart = () => {
+    if (isOffline) {
+      toast.error('You are offline. Trading is disabled until connection is restored.');
+      return;
+    }
     if (!isConnected) {
       connect();
       return;
@@ -404,12 +410,17 @@ export default function MarketDetail() {
                   <Button 
                     className="w-full btn-primary-gradient"
                     onClick={handleTradeStart}
-                    disabled={isLoading}
+                    disabled={isLoading || isOffline}
                   >
                     {isLoading ? (
                       <>
                         <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                         Confirming...
+                      </>
+                    ) : isOffline ? (
+                      <>
+                        <WifiOff className="w-4 h-4 mr-2" />
+                        Offline — Trading Disabled
                       </>
                     ) : !isConnected ? (
                       'Connect Wallet'

--- a/frontend/src/pages/Markets.tsx
+++ b/frontend/src/pages/Markets.tsx
@@ -1,12 +1,14 @@
 import { useState, useMemo, useEffect } from 'react';
-import { Search, Filter, SortAsc, RefreshCw, TrendingUp } from 'lucide-react';
+import { Search, Filter, SortAsc, RefreshCw, TrendingUp, WifiOff } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Layout } from '@/components/layout/Layout';
 import { MarketCard } from '@/components/markets/MarketCard';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { apiService } from '@/services/apiService';
 import { Market } from '@/data/mockData';
+import { useOffline } from '@/hooks/useOffline';
 
 type SortOption = 'volume' | 'newest' | 'ending';
 
@@ -59,6 +61,8 @@ export default function Markets() {
   const [markets, setMarkets] = useState<Market[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isCached, setIsCached] = useState(false);
+  const isOffline = useOffline();
 
   const fetchMarkets = async () => {
     try {
@@ -72,6 +76,7 @@ export default function Markets() {
         if (searchQuery) filters.search = searchQuery;
         
         const response = await apiService.markets.getMarkets(filters);
+        setIsCached(!!(response as any).cached);
         const marketsData = response?.data?.markets || response?.markets || response || [];
         const transformedMarkets = marketsData.map((market: any, index: number) => ({
           id: market.marketId || market._id || `api_${index + 1}`,
@@ -93,11 +98,13 @@ export default function Markets() {
         
         setMarkets(transformedMarkets);
       } catch (apiError) {
+        setIsCached(true);
         setMarkets(demoMarkets);
       }
       
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch markets');
+      setIsCached(true);
       setMarkets(demoMarkets);
     } finally {
       setLoading(false);
@@ -158,16 +165,24 @@ export default function Markets() {
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center justify-between mb-2">
-            <h1 className="text-3xl md:text-4xl font-bold">Discover Markets</h1>
+            <h1 className="text-3xl md:text-4xl font-bold flex items-center gap-3">
+              Discover Markets
+              {isCached && (
+                <Badge variant="outline" className="text-xs border-warning/40 text-warning bg-warning/10 flex items-center gap-1">
+                  <WifiOff className="w-3 h-3" />
+                  Cached
+                </Badge>
+              )}
+            </h1>
             <Button
               onClick={fetchMarkets}
-              disabled={loading}
+              disabled={loading || isOffline}
               variant="outline"
               size="sm"
-              className="flex items-center gap-2 border-white/10 hover:bg-white/5"
+              className="flex items-center gap-2 border-white/10 hover:bg-white/5 disabled:opacity-40"
             >
               <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-              Refresh
+              {isOffline ? 'Offline' : 'Refresh'}
             </Button>
           </div>
           <p className="text-muted-foreground">


### PR DESCRIPTION
- Add useOffline hook: detects navigator.onLine + online/offline events
- Add OfflineBanner: fixed top banner shown globally when offline
- api-client: cache all successful GET responses in localStorage; serve from cache when offline or on network failure
- App.tsx: mount OfflineBanner globally via AppShell wrapper
- MarketDetail: disable trade button + show WifiOff state when offline
- Markets: show 'Cached' badge on header when serving stale data; disable Refresh button when offline

Closes #62 