### PR TITLE
feat: add dynamic market odds visualization (#59)

### DIFF
--- a/frontend/src/components/OddsChart.tsx
+++ b/frontend/src/components/OddsChart.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  AreaChart, Area, XAxis, YAxis, Tooltip,
+  ResponsiveContainer, ReferenceLine, Legend
+} from 'recharts';
+import { Badge } from '@/components/ui/badge';
+import { useMarketUpdates } from '@/contexts/WebSocketContext';
+
+interface OddsPoint {
+  time: string;
+  yes: number; // probability 0–100
+  no: number;
+}
+
+interface OddsChartProps {
+  marketId: string;
+  initialYesPrice: number; // AMM price 0–1
+  initialNoPrice: number;
+}
+
+/** Convert AMM price (0–1) to probability percentage, clamped 1–99 */
+function toProb(price: number): number {
+  return Math.min(99, Math.max(1, Math.round(price * 100)));
+}
+
+function nowLabel(): string {
+  return new Date().toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+}
+
+/** Seed 24-hour history from initial prices with slight noise */
+function seedHistory(yesPrice: number, noPrice: number): OddsPoint[] {
+  return Array.from({ length: 24 }, (_, i) => {
+    const t = new Date(Date.now() - (23 - i) * 60 * 60 * 1000);
+    const label = t.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+    const noise = (Math.random() - 0.5) * 0.04;
+    const y = toProb(Math.min(0.99, Math.max(0.01, yesPrice + Math.sin(i * 0.3) * 0.05 + noise)));
+    return { time: label, yes: y, no: 100 - y };
+  });
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (!active || !payload?.length) return null;
+  const yes = payload.find((p: any) => p.dataKey === 'yes');
+  const no = payload.find((p: any) => p.dataKey === 'no');
+  return (
+    <div className="glass-card px-3 py-2 text-xs border border-white/10 space-y-1">
+      <p className="text-white/50 mb-1">{label}</p>
+      {yes && <p className="text-emerald-400 font-semibold">YES {yes.value}%</p>}
+      {no && <p className="text-red-400 font-semibold">NO {no.value}%</p>}
+    </div>
+  );
+};
+
+export function OddsChart({ marketId, initialYesPrice, initialNoPrice }: OddsChartProps) {
+  const [history, setHistory] = useState<OddsPoint[]>(() =>
+    seedHistory(initialYesPrice, initialNoPrice)
+  );
+  const [liveYes, setLiveYes] = useState(toProb(initialYesPrice));
+  const [isLive, setIsLive] = useState(false);
+  const MAX_POINTS = 60;
+
+  const { marketData, connectionQuality } = useMarketUpdates(marketId);
+
+  // Push new point whenever WebSocket delivers a price update
+  useEffect(() => {
+    if (!marketData) return;
+
+    const rawYes =
+      marketData.prices?.yes ??
+      marketData.currentYesPrice ??
+      marketData.yesPrice;
+
+    if (rawYes == null) return;
+
+    const yesProb = toProb(rawYes);
+    setLiveYes(yesProb);
+    setIsLive(true);
+
+    setHistory(prev => {
+      const next = [...prev, { time: nowLabel(), yes: yesProb, no: 100 - yesProb }];
+      return next.length > MAX_POINTS ? next.slice(next.length - MAX_POINTS) : next;
+    });
+  }, [marketData]);
+
+  const currentYes = history[history.length - 1]?.yes ?? liveYes;
+  const currentNo = 100 - currentYes;
+
+  return (
+    <div className="space-y-3">
+      {/* Live odds pills */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20">
+            <span className="w-2 h-2 rounded-full bg-emerald-400" />
+            <span className="text-sm font-bold text-emerald-400">YES {currentYes}%</span>
+          </div>
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-red-500/10 border border-red-500/20">
+            <span className="w-2 h-2 rounded-full bg-red-400" />
+            <span className="text-sm font-bold text-red-400">NO {currentNo}%</span>
+          </div>
+        </div>
+        <Badge
+          variant="outline"
+          className={`text-[10px] ${
+            isLive && connectionQuality === 'good'
+              ? 'border-emerald-500/30 text-emerald-400 bg-emerald-500/10'
+              : 'border-white/20 text-white/40'
+          }`}
+        >
+          {isLive && connectionQuality === 'good' ? '● LIVE' : 'HISTORICAL'}
+        </Badge>
+      </div>
+
+      {/* Area chart */}
+      <div className="h-[220px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={history} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+            <defs>
+              <linearGradient id="gradYes" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="gradNo" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#ef4444" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="time"
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={10}
+              tickLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              domain={[0, 100]}
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={10}
+              tickLine={false}
+              tickFormatter={(v) => `${v}%`}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <ReferenceLine y={50} stroke="hsl(var(--border))" strokeDasharray="4 4" />
+            <Legend
+              formatter={(value) => (
+                <span className="text-xs text-white/60 capitalize">{value}</span>
+              )}
+            />
+            <Area
+              type="monotone"
+              dataKey="yes"
+              name="YES"
+              stroke="#10b981"
+              strokeWidth={2}
+              fill="url(#gradYes)"
+              dot={false}
+              isAnimationActive={false}
+            />
+            <Area
+              type="monotone"
+              dataKey="no"
+              name="NO"
+              stroke="#ef4444"
+              strokeWidth={2}
+              fill="url(#gradNo)"
+              dot={false}
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MarketDetail.tsx
+++ b/frontend/src/pages/MarketDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, TrendingUp, Users, Calendar, Clock, ExternalLink, Info, Loader2, AlertTriangle } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
@@ -9,11 +9,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Market } from '@/data/mockData';
 import { apiService } from '@/services/apiService';
 import { useWallet } from '@/contexts/WalletContext';
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { toast } from 'sonner';
 import { TradeConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { CountdownTimer } from '@/components/ui/CountdownTimer';
 import { ResolutionPanel } from '@/components/ResolutionPanel';
+import { OddsChart } from '@/components/OddsChart';
+import { useMarketUpdates } from '@/contexts/WebSocketContext';
 
 function formatVolume(volume: number): string {
   if (volume >= 1000000) return `$${(volume / 1000000).toFixed(2)}M`;
@@ -24,6 +25,7 @@ function formatVolume(volume: number): string {
 export default function MarketDetail() {
   const { id } = useParams();
   const { isConnected, connect, publicKey, signTransaction } = useWallet();
+  const { marketData } = useMarketUpdates(id || '');
   const [tradeType, setTradeType] = useState<'buy' | 'sell'>('buy');
   const [position, setPosition] = useState<'YES' | 'NO'>('YES');
   const [amount, setAmount] = useState('');
@@ -89,24 +91,23 @@ export default function MarketDetail() {
 
   // Get the current market
   const currentMarket = demoMarkets[id || ''] || demoMarkets['openai-gpt5-2026'];
-  
-  // Calculate liquidity imbalance
-  const imbalanceRatio = Math.max(currentMarket.yesPrice, currentMarket.noPrice);
-  const isImbalanced = imbalanceRatio >= 0.8;
-  const imbalancedSide = currentMarket.yesPrice > currentMarket.noPrice ? 'YES' : 'NO';
 
-  // Generate price history
-  const priceHistory = Array.from({ length: 24 }, (_, i) => {
-    const time = new Date(Date.now() - (23 - i) * 60 * 60 * 1000).toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-    return {
-      time,
-      yes: Math.max(0.2, Math.min(0.8, currentMarket.yesPrice + Math.sin(i * 0.3) * 0.1 + (Math.random() - 0.5) * 0.05)),
-      no: Math.max(0.2, Math.min(0.8, currentMarket.noPrice - Math.sin(i * 0.3) * 0.1 + (Math.random() - 0.5) * 0.05))
-    };
-  });
+  // Live prices updated via WebSocket; fall back to market initial prices
+  const [liveYesPrice, setLiveYesPrice] = useState(currentMarket.yesPrice);
+  const [liveNoPrice, setLiveNoPrice] = useState(currentMarket.noPrice);
+
+  useEffect(() => {
+    if (!marketData) return;
+    const rawYes = marketData.prices?.yes ?? marketData.currentYesPrice ?? marketData.yesPrice;
+    if (rawYes != null) {
+      setLiveYesPrice(rawYes);
+      setLiveNoPrice(1 - rawYes);
+    }
+  }, [marketData]);
+  
+  const imbalanceRatio = Math.max(liveYesPrice, liveNoPrice);
+  const isImbalanced = imbalanceRatio >= 0.8;
+  const imbalancedSide = liveYesPrice > liveNoPrice ? 'YES' : 'NO';
 
   // Generate demo trades
   const recentTrades = [
@@ -136,7 +137,7 @@ export default function MarketDetail() {
     }
   ];
 
-  const price = position === 'YES' ? currentMarket.yesPrice : currentMarket.noPrice;
+  const price = position === 'YES' ? liveYesPrice : liveNoPrice;
   const tokensReceived = amount ? (parseFloat(amount) / price).toFixed(2) : '0';
   const priceImpact = amount ? Math.min(parseFloat(amount) * 0.001, 2).toFixed(2) : '0';
   const estimatedFee = amount ? (parseFloat(amount) * 0.005).toFixed(4) : '0';
@@ -280,41 +281,27 @@ export default function MarketDetail() {
                 <p className="text-muted-foreground mb-4">{currentMarket.description}</p>
               )}
               
-              {/* Current Prices */}
+              {/* Current Prices — Live */}
               <div className="grid grid-cols-2 gap-4 mt-6">
                 <div className="p-4 rounded-xl bg-success/10 border border-success/20">
                   <div className="text-sm text-muted-foreground mb-1">YES Price</div>
-                  <div className="text-3xl font-bold text-success">{Math.round(currentMarket.yesPrice * 100)}¢</div>
+                  <div className="text-3xl font-bold text-success">{Math.round(liveYesPrice * 100)}¢</div>
                 </div>
                 <div className="p-4 rounded-xl bg-destructive/10 border border-destructive/20">
                   <div className="text-sm text-muted-foreground mb-1">NO Price</div>
-                  <div className="text-3xl font-bold text-destructive">{Math.round(currentMarket.noPrice * 100)}¢</div>
+                  <div className="text-3xl font-bold text-destructive">{Math.round(liveNoPrice * 100)}¢</div>
                 </div>
               </div>
             </div>
 
-            {/* Price Chart */}
+            {/* Dynamic Odds Visualization */}
             <div className="glass-card p-6">
-              <h2 className="text-lg font-semibold mb-4">Price History</h2>
-              <div className="h-[300px]">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={priceHistory}>
-                    <XAxis dataKey="time" stroke="hsl(var(--muted-foreground))" fontSize={12} />
-                    <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} domain={[0, 1]} tickFormatter={(v) => `${v * 100}¢`} />
-                    <Tooltip 
-                      contentStyle={{ 
-                        backgroundColor: 'hsl(var(--card))', 
-                        border: '1px solid hsl(var(--border))',
-                        borderRadius: '8px',
-                      }}
-                      labelStyle={{ color: 'hsl(var(--foreground))' }}
-                    />
-                    <Legend />
-                    <Line type="monotone" dataKey="yes" stroke="hsl(var(--success))" strokeWidth={2} dot={false} name="YES" />
-                    <Line type="monotone" dataKey="no" stroke="hsl(var(--destructive))" strokeWidth={2} dot={false} name="NO" />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
+              <h2 className="text-lg font-semibold mb-4">Market Odds — Live Probability</h2>
+              <OddsChart
+                marketId={currentMarket.id}
+                initialYesPrice={currentMarket.yesPrice}
+                initialNoPrice={currentMarket.noPrice}
+              />
             </div>
 
             {/* Recent Trades */}
@@ -361,14 +348,14 @@ export default function MarketDetail() {
                       className={position === 'YES' ? 'bg-success hover:bg-success/90' : 'hover:border-success hover:text-success'}
                       onClick={() => setPosition('YES')}
                     >
-                      YES {Math.round(currentMarket.yesPrice * 100)}¢
+                      YES {Math.round(liveYesPrice * 100)}¢
                     </Button>
                     <Button
                       variant={position === 'NO' ? 'default' : 'outline'}
                       className={position === 'NO' ? 'bg-destructive hover:bg-destructive/90' : 'hover:border-destructive hover:text-destructive'}
                       onClick={() => setPosition('NO')}
                     >
-                      NO {Math.round(currentMarket.noPrice * 100)}¢
+                      NO {Math.round(liveNoPrice * 100)}¢
                     </Button>
                   </div>
 


### PR DESCRIPTION
- Add OddsChart component: area chart showing YES/NO probability (%) over time with gradient fills, 50% reference line, and custom tooltip
- Seed 24-hour historical data from initial AMM prices on mount
- Subscribe to market WebSocket via useMarketUpdates; push new data point on every price_update event (no animation for smooth streaming)
- Show LIVE / HISTORICAL badge based on WebSocket connection quality
- Live YES/NO probability pills above chart update in real-time
- MarketDetail: replace static LineChart with OddsChart
- Wire liveYesPrice/liveNoPrice state from WebSocket to price pills, position buttons, and trade price calculation
- Remove unused priceHistory generation and recharts line chart imports

Closes #59 