### PR TITLE
feat: add detailed trade breakdown page (#63)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import NotFound from "./pages/NotFound";
 import { Toaster as HotToaster } from "react-hot-toast";
 import SmoothScroll from "@/components/SmoothScroll";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import TradeDetail from "./pages/TradeDetail";
 import IntegrationTest from "./components/IntegrationTest";
 import { RabetWalletTest } from "./components/RabetWalletTest";
 
@@ -41,6 +42,7 @@ const App = () => (
               <Route path="/create" element={<CreateMarket />} />
               <Route path="/leaderboard" element={<Leaderboard />} />
               <Route path="/portfolio" element={<Portfolio />} />
+              <Route path="/trade/:tradeId" element={<TradeDetail />} />
               <Route path="/analytics" element={<Analytics />} />
               <Route path="/governance" element={<Governance />} />
               <Route path="/how-it-works" element={<HowItWorks />} />

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -41,6 +41,7 @@ export const ENDPOINTS = {
   
   // Trades
   TRADES: '/trades',
+  TRADE_DETAIL: (tradeId: string) => `/trades/${tradeId}`,
   TRADE_HISTORY: '/trades/history',
   RECENT_TRADES: '/trades/recent',
   

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { Wallet, TrendingUp, TrendingDown, PieChart, History, ArrowRight, RefreshCw } from 'lucide-react';
+import { Wallet, TrendingUp, TrendingDown, PieChart, History, ArrowRight, RefreshCw, ExternalLink } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -40,10 +40,11 @@ export default function Portfolio() {
       setLoading(true);
       setError(null);
       
-      const [positionsData, statsData, profile] = await Promise.all([
+      const [positionsData, statsData, profile, tradesData] = await Promise.all([
         apiService.users.getUserPositions(publicKey, { status: 'active', limit: 50 }),
         apiService.users.getUserStats(publicKey, { timeframe: '30d' }),
-        apiService.users.getUserByAddress(publicKey)
+        apiService.users.getUserByAddress(publicKey),
+        apiService.trades.getTradeHistory(publicKey, { limit: 10 }).catch(() => [])
       ]);
 
       const mappedPositions: Position[] = (positionsData || []).map((position: any) => {
@@ -64,7 +65,7 @@ export default function Portfolio() {
       });
 
       setUserPositions(mappedPositions);
-      setTradeHistory([]);
+      setTradeHistory(tradesData?.trades || tradesData || []);
 
       const winRatePercent = Number((profile?.statistics?.winRate || 0) * 100);
 
@@ -269,16 +270,53 @@ export default function Portfolio() {
           </div>
         </MagicCard>
 
-        {/* Trade History Preview */}
+        {/* Trade History */}
         <MagicCard className="glass-card p-6" gradientColor="#262626">
           <div className="flex items-center justify-between mb-6">
             <h2 className="text-xl font-semibold">Recent Trade History</h2>
-            <Button variant="ghost" size="sm">View All</Button>
           </div>
-          <div className="text-center py-8 text-muted-foreground">
-            <History className="w-12 h-12 mx-auto mb-4 opacity-50" />
-            <p>Your completed trades will appear here</p>
-          </div>
+          {tradeHistory.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <History className="w-12 h-12 mx-auto mb-4 opacity-50" />
+              <p>Your completed trades will appear here</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {tradeHistory.map((trade: any) => (
+                <Link
+                  key={trade.tradeId || trade._id}
+                  to={`/trade/${trade.tradeId || trade._id}`}
+                  className="flex items-center justify-between p-4 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors group"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className={`w-2 h-2 rounded-full ${trade.tradeType === 'buy' ? 'bg-success' : 'bg-destructive'}`} />
+                    <div>
+                      <p className="text-sm font-medium capitalize">
+                        {trade.tradeType} {trade.tokenType?.toUpperCase()} — {trade.amount} tokens
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(trade.timestamp || trade.createdAt).toLocaleDateString()}
+                        {' · '}
+                        {Math.round((trade.price ?? 0) * 100)}¢ per token
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <div className="text-right">
+                      <p className="text-sm font-semibold">
+                        {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(trade.totalCost ?? 0)}
+                      </p>
+                      <p className={`text-xs capitalize ${
+                        trade.status === 'confirmed' ? 'text-success' :
+                        trade.status === 'failed' ? 'text-destructive' : 'text-warning'
+                      }`}>{trade.status}</p>
+                    </div>
+                    <ExternalLink className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
         </MagicCard>
       </div>
     </Layout>

--- a/frontend/src/pages/TradeDetail.tsx
+++ b/frontend/src/pages/TradeDetail.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import {
+  ArrowLeft, ExternalLink, CheckCircle2, XCircle,
+  Clock, TrendingUp, Layers, Percent, Receipt, Hash
+} from 'lucide-react';
+import { Layout } from '@/components/layout/Layout';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { apiService } from '@/services/apiService';
+
+const STELLAR_EXPERT_BASE = 'https://stellar.expert/explorer/testnet/tx';
+
+function fmt(n: number, decimals = 4) {
+  return Number(n ?? 0).toFixed(decimals);
+}
+function fmtUSD(n: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n ?? 0);
+}
+function fmtDate(d: string) {
+  return new Date(d).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'medium' });
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, { label: string; cls: string }> = {
+    confirmed:        { label: 'Confirmed',        cls: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30' },
+    partially_filled: { label: 'Partially Filled', cls: 'bg-warning/10 text-warning border-warning/30' },
+    pending:          { label: 'Pending',           cls: 'bg-blue-500/10 text-blue-400 border-blue-500/30' },
+    failed:           { label: 'Failed',            cls: 'bg-red-500/10 text-red-400 border-red-500/30' },
+    cancelled:        { label: 'Cancelled',         cls: 'border-white/10 text-white/50' },
+  };
+  const cfg = map[status] ?? { label: status, cls: 'border-white/10 text-white/60' };
+  return (
+    <Badge variant="outline" className={`text-xs font-semibold ${cfg.cls}`}>
+      {status === 'confirmed' && <CheckCircle2 className="w-3 h-3 mr-1" />}
+      {status === 'failed'    && <XCircle      className="w-3 h-3 mr-1" />}
+      {status === 'pending'   && <Clock        className="w-3 h-3 mr-1" />}
+      {cfg.label}
+    </Badge>
+  );
+}
+
+function Row({ label, value, mono = false, highlight }: {
+  label: string; value: React.ReactNode; mono?: boolean;
+  highlight?: 'success' | 'danger' | 'warn';
+}) {
+  const color = highlight === 'success' ? 'text-emerald-400'
+    : highlight === 'danger' ? 'text-red-400'
+    : highlight === 'warn' ? 'text-warning' : '';
+  return (
+    <div className="flex items-center justify-between py-3 border-b border-white/5 last:border-0">
+      <span className="text-sm text-white/50">{label}</span>
+      <span className={`text-sm font-medium ${mono ? 'font-mono text-xs' : ''} ${color}`}>{value}</span>
+    </div>
+  );
+}
+
+function Section({ title, icon: Icon, children }: {
+  title: string; icon: React.ElementType; children: React.ReactNode;
+}) {
+  return (
+    <div className="glass-card p-6">
+      <h2 className="text-base font-semibold flex items-center gap-2 mb-2">
+        <Icon className="w-4 h-4 text-primary" />
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+export default function TradeDetail() {
+  const { tradeId } = useParams<{ tradeId: string }>();
+  const [trade, setTrade] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!tradeId) return;
+    setLoading(true);
+    apiService.trades.getTradeById(tradeId)
+      .then(setTrade)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [tradeId]);
+
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-8 max-w-3xl">
+        <Link
+          to="/portfolio"
+          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6 transition-colors text-sm"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Portfolio
+        </Link>
+
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold">Trade Breakdown</h1>
+          {trade && <StatusBadge status={trade.status} />}
+        </div>
+
+        {loading && (
+          <div className="space-y-4">
+            {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-40 w-full rounded-xl" />)}
+          </div>
+        )}
+
+        {error && (
+          <div className="glass-card p-8 text-center text-red-400">
+            <XCircle className="w-8 h-8 mx-auto mb-2" />
+            <p className="font-medium">Failed to load trade</p>
+            <p className="text-sm text-white/40 mt-1">{error}</p>
+          </div>
+        )}
+
+        {trade && !loading && (
+          <div className="space-y-4">
+            {/* Execution Summary */}
+            <Section title="Execution Summary" icon={TrendingUp}>
+              <Row label="Trade ID"   value={trade.tradeId} mono />
+              <Row label="Market"     value={trade.marketId} />
+              <Row label="Type" value={
+                <span className="flex items-center gap-2">
+                  <Badge variant="outline" className={trade.tradeType === 'buy'
+                    ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
+                    : 'bg-red-500/10 text-red-400 border-red-500/30'}>
+                    {trade.tradeType?.toUpperCase()}
+                  </Badge>
+                  <Badge variant="outline" className={trade.tokenType === 'yes'
+                    ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
+                    : 'bg-red-500/10 text-red-400 border-red-500/30'}>
+                    {trade.tokenType?.toUpperCase()}
+                  </Badge>
+                </span>
+              } />
+              <Row label="Timestamp" value={fmtDate(trade.timestamp || trade.createdAt)} />
+              <Row label="Status"    value={<StatusBadge status={trade.status} />} />
+            </Section>
+
+            {/* Price & Amount */}
+            <Section title="Price & Amount" icon={Layers}>
+              <Row label="Requested Amount" value={`${fmt(trade.amount)} tokens`} />
+              {trade.partialFill?.isPartial && <>
+                <Row label="Filled Amount"   value={`${fmt(trade.partialFill.filledAmount)} tokens`}   highlight="success" />
+                <Row label="Remaining"       value={`${fmt(trade.partialFill.remainingAmount)} tokens`} highlight="warn" />
+                <Row label="Fill Ratio"      value={`${(trade.partialFill.fillRatio * 100).toFixed(1)}%`} highlight="warn" />
+              </>}
+              <Row label="Executed Price" value={`${Math.round((trade.price ?? 0) * 100)}¢ per token`} />
+              <Row label="Total Cost"     value={fmtUSD(trade.totalCost)} />
+            </Section>
+
+            {/* Slippage */}
+            <Section title="Slippage" icon={Percent}>
+              <Row label="Max Slippage Tolerance" value={`${fmt((trade.slippage?.expected ?? 0) * 100, 2)}%`} />
+              <Row
+                label="Actual Price Impact"
+                value={`${fmt((trade.slippage?.actual ?? 0) * 100, 2)}%`}
+                highlight={(trade.slippage?.actual ?? 0) > 0.02 ? 'warn' : 'success'}
+              />
+              {trade.marketPrices && <>
+                <Row label="YES Price Before" value={`${Math.round((trade.marketPrices.yesPriceBefore ?? 0) * 100)}¢`} />
+                <Row label="YES Price After"  value={`${Math.round((trade.marketPrices.yesPriceAfter  ?? 0) * 100)}¢`} />
+              </>}
+            </Section>
+
+            {/* Fees */}
+            <Section title="Fees" icon={Receipt}>
+              <Row label="Platform Fee" value={fmtUSD(trade.fees?.platformFee ?? 0)} />
+              <Row label="Network Fee"  value={`${trade.fees?.stellarFee ?? 0.00001} XLM`} />
+              <Row label="Total Fees"   value={fmtUSD(trade.fees?.total ?? 0)} highlight="warn" />
+            </Section>
+
+            {/* Blockchain */}
+            <Section title="Blockchain" icon={Hash}>
+              <Row
+                label="Transaction Hash"
+                value={trade.stellarTransactionHash ? (
+                  <a
+                    href={`${STELLAR_EXPERT_BASE}/${trade.stellarTransactionHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-primary hover:underline font-mono text-xs"
+                  >
+                    {trade.stellarTransactionHash.slice(0, 16)}…{trade.stellarTransactionHash.slice(-8)}
+                    <ExternalLink className="w-3 h-3 shrink-0" />
+                  </a>
+                ) : <span className="text-white/30">Not available</span>}
+              />
+              {trade.blockHeight && (
+                <Row label="Block Height" value={trade.blockHeight.toLocaleString()} mono />
+              )}
+              <Row
+                label="View on Explorer"
+                value={trade.stellarTransactionHash ? (
+                  <a
+                    href={`${STELLAR_EXPERT_BASE}/${trade.stellarTransactionHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-primary hover:underline text-xs"
+                  >
+                    Stellar Expert <ExternalLink className="w-3 h-3" />
+                  </a>
+                ) : '—'}
+              />
+            </Section>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -382,6 +382,15 @@ export const tradeService = {
     }
     return response.data;
   },
+
+  // Get single trade by ID
+  async getTradeById(tradeId: string): Promise<any> {
+    const response = await apiClient.get(ENDPOINTS.TRADE_DETAIL(tradeId));
+    if (!response.success) {
+      throw new Error(response.message || 'Trade not found');
+    }
+    return response.data;
+  },
 };
 
 // Leaderboard Services


### PR DESCRIPTION
- Add TradeDetail page (/trade/:tradeId) with 5 sections: Execution Summary, Price & Amount, Slippage, Fees, Blockchain
- StatusBadge component with color-coded confirmed/partial/pending/failed states
- Slippage section shows max tolerance vs actual price impact with color highlight (warn if >2%), YES price before/after
- Fees section breaks down platform fee, network fee, total
- Blockchain section links tx hash and 'View on Explorer' to Stellar Expert testnet explorer (external link)
- Partial fill rows (filled/remaining/ratio) shown when applicable
- Skeleton loading state while fetching
- Add TRADE_DETAIL endpoint to api-config.ts
- Add getTradeById() to tradeService in apiService.ts
- Register /trade/:tradeId route in App.tsx
- Portfolio: fetch real trade history, render linked rows to TradeDetail


Closes: #63 