### PR TITLE
feat: env validation, abuse detection, push notifications & advanced leaderboard metrics

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,8 +5,8 @@ PORT=5001
 # Database Configuration
 MONGODB_URI=mongodb://localhost:27017/oryn-finance
 
-# JWT Configuration
-#JWT_SECRET=your-super-secret-jwt-key-change-in-production
+# JWT Configuration — JWT_SECRET is required and must be at least 32 characters
+JWT_SECRET=your-super-secret-jwt-key-change-in-production-min-32-chars
 #JWT_EXPIRES_IN=7d
 # Issue #22: use a separate secret for refresh tokens (falls back to JWT_SECRET if unset)
 #REFRESH_TOKEN_SECRET=your-refresh-token-secret-change-in-production
@@ -34,6 +34,11 @@ NEWS_API_KEY=your-news-api-key
 # Rate Limiting Configuration
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
+
+# Push Notifications (Web Push / VAPID) — generate with: npx web-push generate-vapid-keys
+#VAPID_PUBLIC_KEY=your-vapid-public-key
+#VAPID_PRIVATE_KEY=your-vapid-private-key
+#VAPID_SUBJECT=mailto:admin@oryn.finance
 
 # Socket.IO Configuration
 SOCKET_IO_ORIGINS=http://localhost:8080

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
     "stellar-sdk": "^12.0.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0",
+    "web-push": "^3.6.7",
     "winston": "^3.11.0"
   },
   "overrides": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,7 +10,9 @@ require('dotenv').config();
 
 const connectDB = require('./src/config/database');
 const logger = require('./src/config/logger');
+const { validateEnv } = require('./src/config/envValidator');
 const { errorHandler, notFound } = require('./src/middleware/errorHandler');
+const { detectAbuse } = require('./src/middleware/abuseDetection');
 
 // Import routes
 const authRoutes = require('./src/routes/auth');       // Issue #22: httpOnly cookie auth
@@ -24,12 +26,14 @@ const analyticsRoutes = require('./src/routes/analytics');
 const adminRoutes = require('./src/routes/admin');
 const oracleRoutes = require('./src/routes/oracle');
 const liquidityRoutes = require('./src/routes/liquidity');
+const pushNotificationRoutes = require('./src/routes/pushNotifications');
 
 // Import services
 const backgroundJobs = require('./src/services/backgroundJobs');
 const websocketHandler = require('./src/services/websocketHandler');
 const contractEventIndexer = require('./src/services/contractEventIndexer');
 const transactionRetryQueue = require('./src/services/transactionRetryQueue'); // Issue #23
+const pushNotificationService = require('./src/services/pushNotificationService');
 
 class OrynBackendServer {
   constructor() {
@@ -46,6 +50,12 @@ class OrynBackendServer {
 
   async initialize() {
     try {
+      // Validate required environment variables before anything else
+      validateEnv();
+
+      // Initialize push notification VAPID keys
+      pushNotificationService.initVapid();
+
       // Connect to database (optional for now)
       try {
         await connectDB();
@@ -97,6 +107,9 @@ class OrynBackendServer {
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
       allowedHeaders: ['Content-Type', 'Authorization']
     }));
+
+    // Abuse detection (pattern analysis + IP blocking)
+    this.app.use('/api/', detectAbuse);
 
     // Rate limiting
     const limiter = rateLimit({
@@ -168,6 +181,9 @@ class OrynBackendServer {
 
     // Transaction routes (mixed auth - some endpoints require auth, others don't)
     this.app.use('/api/transactions', transactionRoutes);
+
+    // Push notification routes
+    this.app.use('/api/push', pushNotificationRoutes);
 
     // Protected routes
     this.app.use('/api/trades', tradeRoutes);

--- a/backend/src/config/envValidator.js
+++ b/backend/src/config/envValidator.js
@@ -1,0 +1,86 @@
+const logger = require('./logger');
+
+const ENV_RULES = [
+  {
+    key: 'JWT_SECRET',
+    required: true,
+    validate: (v) => v.length >= 32,
+    hint: 'Must be at least 32 characters long',
+  },
+  {
+    key: 'MONGODB_URI',
+    required: true,
+    validate: (v) => v.startsWith('mongodb://') || v.startsWith('mongodb+srv://'),
+    hint: 'Must be a valid MongoDB connection string',
+  },
+  {
+    key: 'NODE_ENV',
+    required: false,
+    validate: (v) => ['development', 'production', 'test'].includes(v),
+    hint: 'Must be development, production, or test',
+  },
+  {
+    key: 'PORT',
+    required: false,
+    validate: (v) => {
+      const n = parseInt(v, 10);
+      return !isNaN(n) && n > 0 && n < 65536;
+    },
+    hint: 'Must be a valid port number (1-65535)',
+  },
+  {
+    key: 'FRONTEND_URL',
+    required: false,
+    validate: (v) => {
+      try {
+        new URL(v);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    hint: 'Must be a valid URL',
+  },
+];
+
+function validateEnv() {
+  const errors = [];
+  const warnings = [];
+
+  for (const rule of ENV_RULES) {
+    const value = process.env[rule.key];
+
+    if (!value || value.trim() === '') {
+      if (rule.required) {
+        errors.push(`${rule.key} is required but not set. ${rule.hint || ''}`);
+      } else {
+        warnings.push(`${rule.key} is not set — using default. ${rule.hint || ''}`);
+      }
+      continue;
+    }
+
+    if (rule.validate && !rule.validate(value)) {
+      if (rule.required) {
+        errors.push(`${rule.key} has an invalid value. ${rule.hint || ''}`);
+      } else {
+        warnings.push(`${rule.key} may be misconfigured. ${rule.hint || ''}`);
+      }
+    }
+  }
+
+  for (const msg of warnings) {
+    logger.warn(`[ENV] ${msg}`);
+  }
+
+  if (errors.length > 0) {
+    for (const msg of errors) {
+      logger.error(`[ENV] ${msg}`);
+    }
+    logger.error('[ENV] Server startup aborted due to missing required environment variables.');
+    process.exit(1);
+  }
+
+  logger.info('[ENV] Environment validation passed.');
+}
+
+module.exports = { validateEnv };

--- a/backend/src/controllers/leaderboardController.js
+++ b/backend/src/controllers/leaderboardController.js
@@ -249,6 +249,83 @@ class LeaderboardController {
     }
   }
 
+  // Get advanced leaderboard metrics: win-rate leaders, ROI leaders, most accurate trader badge
+  static async getAdvancedMetrics(req, res) {
+    try {
+      const { limit = 20 } = req.query;
+      const parsedLimit = Math.min(50, Math.max(1, parseInt(limit, 10) || 20));
+
+      // Win-rate leaders — users with most predictions and best win rate
+      const winRateLeaders = await User.find({
+        isActive: true,
+        'statistics.totalPredictions': { $gte: 5 },
+      })
+        .sort({ 'statistics.winRate': -1, 'statistics.totalPredictions': -1 })
+        .limit(parsedLimit)
+        .lean();
+
+      // ROI leaders — sort by profit/loss relative to volume
+      const roiLeaders = await User.find({
+        isActive: true,
+        'statistics.totalVolume': { $gt: 0 },
+      })
+        .lean()
+        .then((users) =>
+          users
+            .map((u) => ({
+              ...u,
+              roi:
+                u.statistics.totalVolume > 0
+                  ? ((u.statistics.profitLoss / u.statistics.totalVolume) * 100)
+                  : 0,
+            }))
+            .sort((a, b) => b.roi - a.roi)
+            .slice(0, parsedLimit)
+        );
+
+      // Most accurate trader — highest win rate with minimum 10 trades
+      const mostAccurate = await User.find({
+        isActive: true,
+        'statistics.totalPredictions': { $gte: 10 },
+      })
+        .sort({ 'statistics.winRate': -1 })
+        .limit(1)
+        .lean();
+
+      const formatUser = (user, index, extra = {}) => ({
+        rank: index + 1,
+        walletAddress: user.walletAddress,
+        username: user.username || null,
+        reputationScore: user.reputationScore || 0,
+        level: user.level || 'rookie',
+        totalPredictions: user.statistics?.totalPredictions || 0,
+        successfulPredictions: user.statistics?.successfulPredictions || 0,
+        winRate: Number(((user.statistics?.winRate || 0) * 100).toFixed(2)),
+        totalVolume: user.statistics?.totalVolume || 0,
+        profitLoss: user.statistics?.profitLoss || 0,
+        ...extra,
+      });
+
+      res.json({
+        success: true,
+        data: {
+          winRateLeaders: winRateLeaders.map((u, i) => formatUser(u, i)),
+          roiLeaders: roiLeaders.map((u, i) =>
+            formatUser(u, i, { roi: Number(u.roi.toFixed(2)) })
+          ),
+          mostAccurateTrader:
+            mostAccurate.length > 0
+              ? { ...formatUser(mostAccurate[0], 0), badge: 'most-accurate-trader' }
+              : null,
+        },
+        metadata: { limit: parsedLimit },
+      });
+    } catch (error) {
+      logger.error('Get advanced leaderboard metrics failed:', error);
+      throw error;
+    }
+  }
+
   // Get user's rank and position
   static async getUserRank(req, res) {
     try {

--- a/backend/src/middleware/abuseDetection.js
+++ b/backend/src/middleware/abuseDetection.js
@@ -1,0 +1,97 @@
+const logger = require('../config/logger');
+
+const WINDOW_MS = 60 * 1000;
+const SUSPICIOUS_THRESHOLD = 60;
+const BLOCK_THRESHOLD = 100;
+const BLOCK_DURATION_MS = 15 * 60 * 1000;
+
+const ipWindows = new Map();
+const blockedIPs = new Map();
+
+function getClientIP(req) {
+  return (
+    req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+    req.socket?.remoteAddress ||
+    req.ip
+  );
+}
+
+function isBlocked(ip) {
+  const blockedUntil = blockedIPs.get(ip);
+  if (!blockedUntil) return false;
+  if (Date.now() < blockedUntil) return true;
+  blockedIPs.delete(ip);
+  return false;
+}
+
+function recordRequest(ip) {
+  const now = Date.now();
+  if (!ipWindows.has(ip)) ipWindows.set(ip, []);
+  const timestamps = ipWindows.get(ip).filter((t) => now - t < WINDOW_MS);
+  timestamps.push(now);
+  ipWindows.set(ip, timestamps);
+  return timestamps.length;
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, timestamps] of ipWindows.entries()) {
+    const active = timestamps.filter((t) => now - t < WINDOW_MS);
+    if (active.length === 0) ipWindows.delete(ip);
+    else ipWindows.set(ip, active);
+  }
+  for (const [ip, until] of blockedIPs.entries()) {
+    if (now >= until) blockedIPs.delete(ip);
+  }
+}, WINDOW_MS);
+
+function detectAbuse(req, res, next) {
+  const ip = getClientIP(req);
+
+  if (isBlocked(ip)) {
+    const until = blockedIPs.get(ip);
+    const retryAfter = Math.ceil((until - Date.now()) / 1000);
+    logger.warn('[ABUSE] Blocked IP attempted request', {
+      ip,
+      path: req.path,
+      method: req.method,
+      retryAfter,
+    });
+    return res.status(429).json({
+      success: false,
+      message: 'Your IP has been temporarily blocked due to suspicious activity.',
+      retryAfter,
+    });
+  }
+
+  const count = recordRequest(ip);
+
+  if (count >= BLOCK_THRESHOLD) {
+    blockedIPs.set(ip, Date.now() + BLOCK_DURATION_MS);
+    logger.warn('[ABUSE] IP blocked after exceeding threshold', {
+      ip,
+      count,
+      path: req.path,
+      method: req.method,
+      blockedForMinutes: BLOCK_DURATION_MS / 60000,
+    });
+    return res.status(429).json({
+      success: false,
+      message: 'Too many requests. Your IP has been temporarily blocked.',
+      retryAfter: BLOCK_DURATION_MS / 1000,
+    });
+  }
+
+  if (count >= SUSPICIOUS_THRESHOLD) {
+    logger.warn('[ABUSE] Suspicious request pattern detected', {
+      ip,
+      count,
+      path: req.path,
+      method: req.method,
+    });
+  }
+
+  next();
+}
+
+module.exports = { detectAbuse };

--- a/backend/src/routes/leaderboard.js
+++ b/backend/src/routes/leaderboard.js
@@ -27,4 +27,10 @@ router.get('/user-rank',
   asyncHandler(leaderboardController.getUserRank)
 );
 
+// Get advanced metrics: win-rate leaders, ROI leaders, most accurate trader
+router.get('/advanced-metrics',
+  optionalAuth,
+  asyncHandler(leaderboardController.getAdvancedMetrics)
+);
+
 module.exports = router;

--- a/backend/src/routes/pushNotifications.js
+++ b/backend/src/routes/pushNotifications.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const router = express.Router();
+const { asyncHandler } = require('../middleware/errorHandler');
+const { authenticateToken } = require('../middleware/auth');
+const pushService = require('../services/pushNotificationService');
+const logger = require('../config/logger');
+
+// GET /api/push/vapid-public-key
+router.get('/vapid-public-key', (req, res) => {
+  const key = pushService.getPublicKey();
+  if (!key) {
+    return res.status(503).json({
+      success: false,
+      message: 'Push notifications are not configured on this server.',
+    });
+  }
+  res.json({ success: true, data: { publicKey: key } });
+});
+
+// POST /api/push/subscribe
+router.post(
+  '/subscribe',
+  authenticateToken,
+  asyncHandler(async (req, res) => {
+    const { subscription } = req.body;
+
+    if (!subscription || !subscription.endpoint) {
+      return res.status(400).json({ success: false, message: 'Invalid subscription object.' });
+    }
+
+    pushService.saveSubscription(req.user.walletAddress, subscription);
+
+    logger.info('[PUSH] New subscription registered', { walletAddress: req.user.walletAddress });
+
+    res.json({ success: true, message: 'Push notifications enabled.' });
+  })
+);
+
+// DELETE /api/push/subscribe
+router.delete(
+  '/subscribe',
+  authenticateToken,
+  asyncHandler(async (req, res) => {
+    pushService.removeSubscription(req.user.walletAddress);
+    res.json({ success: true, message: 'Push notifications disabled.' });
+  })
+);
+
+module.exports = router;

--- a/backend/src/services/pushNotificationService.js
+++ b/backend/src/services/pushNotificationService.js
@@ -1,0 +1,83 @@
+const webpush = require('web-push');
+const logger = require('../config/logger');
+
+// In-memory subscription store keyed by walletAddress
+const subscriptions = new Map();
+
+function getVapidKeys() {
+  const publicKey = process.env.VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+  const subject = process.env.VAPID_SUBJECT || 'mailto:admin@oryn.finance';
+
+  if (!publicKey || !privateKey) {
+    logger.warn('[PUSH] VAPID keys not configured — push notifications disabled');
+    return null;
+  }
+
+  return { publicKey, privateKey, subject };
+}
+
+function isConfigured() {
+  return !!getVapidKeys();
+}
+
+function initVapid() {
+  const keys = getVapidKeys();
+  if (!keys) return;
+  webpush.setVapidDetails(keys.subject, keys.publicKey, keys.privateKey);
+  logger.info('[PUSH] VAPID keys loaded — push notifications enabled');
+}
+
+function saveSubscription(walletAddress, subscription) {
+  subscriptions.set(walletAddress.toLowerCase(), subscription);
+  logger.info('[PUSH] Subscription saved', { walletAddress });
+}
+
+function removeSubscription(walletAddress) {
+  subscriptions.delete(walletAddress.toLowerCase());
+  logger.info('[PUSH] Subscription removed', { walletAddress });
+}
+
+async function sendToWallet(walletAddress, payload) {
+  if (!isConfigured()) return;
+  const subscription = subscriptions.get(walletAddress.toLowerCase());
+  if (!subscription) return;
+
+  try {
+    await webpush.sendNotification(subscription, JSON.stringify(payload));
+  } catch (error) {
+    if (error.statusCode === 410 || error.statusCode === 404) {
+      subscriptions.delete(walletAddress.toLowerCase());
+      logger.info('[PUSH] Stale subscription removed', { walletAddress });
+    } else {
+      logger.error('[PUSH] Failed to send push notification', { walletAddress, error: error.message });
+    }
+  }
+}
+
+async function notifyTradeExecuted(walletAddress, { marketTitle, action, amount }) {
+  await sendToWallet(walletAddress, {
+    title: 'Trade Executed',
+    body: `Your ${action} of ${amount} on "${marketTitle}" was confirmed.`,
+    tag: 'trade-executed',
+  });
+}
+
+async function notifyMarketResolved(walletAddress, { marketTitle, outcome }) {
+  await sendToWallet(walletAddress, {
+    title: 'Market Resolved',
+    body: `"${marketTitle}" has been resolved: ${outcome}`,
+    tag: 'market-resolved',
+  });
+}
+
+module.exports = {
+  initVapid,
+  isConfigured,
+  saveSubscription,
+  removeSubscription,
+  sendToWallet,
+  notifyTradeExecuted,
+  notifyMarketResolved,
+  getPublicKey: () => getVapidKeys()?.publicKey || null,
+};

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,27 @@
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: 'Oryn Finance', body: event.data.text() };
+  }
+
+  const { title = 'Oryn Finance', body = '', tag = 'oryn-notification', url = '/' } = payload;
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      tag,
+      icon: '/favicon.ico',
+      data: { url },
+    })
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url || '/';
+  event.waitUntil(clients.openWindow(url));
+});

--- a/frontend/src/components/NotificationPreferences.tsx
+++ b/frontend/src/components/NotificationPreferences.tsx
@@ -1,0 +1,37 @@
+import { Bell, BellOff, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { usePushNotifications } from '@/hooks/usePushNotifications';
+
+interface Props {
+  authToken: string | null;
+}
+
+export function NotificationPreferences({ authToken }: Props) {
+  const { supported, subscribed, loading, subscribe, unsubscribe } = usePushNotifications(authToken);
+
+  if (!supported) return null;
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-muted-foreground">
+        {subscribed ? 'Push notifications on' : 'Push notifications off'}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={loading || !authToken}
+        onClick={subscribed ? unsubscribe : subscribe}
+        className="flex items-center gap-2"
+      >
+        {loading ? (
+          <Loader2 className="w-4 h-4 animate-spin" />
+        ) : subscribed ? (
+          <BellOff className="w-4 h-4" />
+        ) : (
+          <Bell className="w-4 h-4" />
+        )}
+        {subscribed ? 'Disable' : 'Enable'}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePushNotifications.ts
+++ b/frontend/src/hooks/usePushNotifications.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  subscribeToPushNotifications,
+  unsubscribeFromPushNotifications,
+  isPushSubscribed,
+  isPushSupported,
+} from '@/services/pushNotificationService';
+
+export function usePushNotifications(authToken: string | null) {
+  const [supported, setSupported] = useState(false);
+  const [subscribed, setSubscribed] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setSupported(isPushSupported());
+    isPushSubscribed().then(setSubscribed);
+  }, []);
+
+  const subscribe = useCallback(async () => {
+    if (!authToken) return;
+    setLoading(true);
+    try {
+      const ok = await subscribeToPushNotifications(authToken);
+      setSubscribed(ok);
+    } finally {
+      setLoading(false);
+    }
+  }, [authToken]);
+
+  const unsubscribe = useCallback(async () => {
+    if (!authToken) return;
+    setLoading(true);
+    try {
+      const ok = await unsubscribeFromPushNotifications(authToken);
+      if (ok) setSubscribed(false);
+    } finally {
+      setLoading(false);
+    }
+  }, [authToken]);
+
+  return { supported, subscribed, loading, subscribe, unsubscribe };
+}

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -55,6 +55,11 @@ export const ENDPOINTS = {
   // Leaderboard
   LEADERBOARD: '/leaderboard',
   REPUTATION_LEADERBOARD: '/leaderboard/reputation',
+  LEADERBOARD_ADVANCED: '/leaderboard/advanced-metrics',
+
+  // Push Notifications
+  PUSH_VAPID_KEY: '/push/vapid-public-key',
+  PUSH_SUBSCRIBE: '/push/subscribe',
   
   // Analytics
   ANALYTICS: '/analytics',

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Trophy, Medal, TrendingUp, Percent, Hash, Star, RefreshCw, Loader2 } from 'lucide-react';
+import { Trophy, Medal, TrendingUp, Percent, Hash, Star, RefreshCw, Loader2, Target, DollarSign, Award } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -9,6 +9,22 @@ import { MagicCard } from '@/components/magicui/magic-card';
 import { toast } from 'sonner';
 
 type TimeFrame = 'all' | 'monthly' | 'weekly';
+type MetricsTab = 'reputation' | 'winrate' | 'roi';
+
+interface AdvancedEntry {
+  rank: number;
+  walletAddress: string;
+  username: string | null;
+  winRate: number;
+  totalPredictions: number;
+  successfulPredictions: number;
+  reputationScore: number;
+  level: string;
+  totalVolume?: number;
+  profitLoss?: number;
+  roi?: number;
+  badge?: string;
+}
 
 function formatReputation(score: number): string {
   if (score >= 1000) {
@@ -31,7 +47,11 @@ const rankBgColors: Record<number, string> = {
 
 export default function Leaderboard() {
   const [timeFrame, setTimeFrame] = useState<TimeFrame>('all');
+  const [activeTab, setActiveTab] = useState<MetricsTab>('reputation');
   const [leaderboardData, setLeaderboardData] = useState<LeaderboardEntry[]>([]);
+  const [winRateLeaders, setWinRateLeaders] = useState<AdvancedEntry[]>([]);
+  const [roiLeaders, setRoiLeaders] = useState<AdvancedEntry[]>([]);
+  const [mostAccurate, setMostAccurate] = useState<AdvancedEntry | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -39,17 +59,30 @@ export default function Leaderboard() {
     try {
       setLoading(true);
       setError(null);
-      const data = await apiService.leaderboard.getReputationLeaderboard(50);
-      const mapped: LeaderboardEntry[] = data.map((item: any) => ({
-        rank: item.rank,
-        address: item.walletAddress,
-        username: item.username || undefined,
-        totalProfit: Number(item.reputationScore || 0),
-        trades: Number(item.totalPredictions || 0),
-        winRate: Number(((item.winRate || 0) * 100).toFixed(2)),
-        favoriteCategory: item.level || 'rookie'
-      }));
-      setLeaderboardData(mapped);
+
+      const [reputationData, advancedData] = await Promise.allSettled([
+        apiService.leaderboard.getReputationLeaderboard(50),
+        apiService.leaderboard.getAdvancedMetrics(20),
+      ]);
+
+      if (reputationData.status === 'fulfilled') {
+        const mapped: LeaderboardEntry[] = reputationData.value.map((item: any) => ({
+          rank: item.rank,
+          address: item.walletAddress,
+          username: item.username || undefined,
+          totalProfit: Number(item.reputationScore || 0),
+          trades: Number(item.totalPredictions || 0),
+          winRate: Number(((item.winRate || 0) * 100).toFixed(2)),
+          favoriteCategory: item.level || 'rookie',
+        }));
+        setLeaderboardData(mapped);
+      }
+
+      if (advancedData.status === 'fulfilled' && advancedData.value) {
+        setWinRateLeaders(advancedData.value.winRateLeaders || []);
+        setRoiLeaders(advancedData.value.roiLeaders || []);
+        setMostAccurate(advancedData.value.mostAccurateTrader || null);
+      }
     } catch (err: any) {
       setError(err.message || 'Failed to load leaderboard');
       toast.error(err.message || 'Failed to load leaderboard');
@@ -98,7 +131,7 @@ export default function Leaderboard() {
         </div>
 
         {/* Time Frame Filter */}
-        <div className="flex justify-center gap-2 mb-10">
+        <div className="flex justify-center gap-2 mb-6">
           {(['all', 'monthly', 'weekly'] as TimeFrame[]).map((tf) => (
             <Button
               key={tf}
@@ -110,6 +143,40 @@ export default function Leaderboard() {
               {tf === 'all' ? 'All Time' : tf}
             </Button>
           ))}
+        </div>
+
+        {/* Metrics Tab Switcher */}
+        <div className="flex justify-center gap-2 mb-10">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={loading}
+            onClick={() => setActiveTab('reputation')}
+            className={`flex items-center gap-1 ${activeTab === 'reputation' ? 'active tab-button' : ''}`}
+          >
+            <Trophy className="w-4 h-4" />
+            Reputation
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={loading}
+            onClick={() => setActiveTab('winrate')}
+            className={`flex items-center gap-1 ${activeTab === 'winrate' ? 'active tab-button' : ''}`}
+          >
+            <Target className="w-4 h-4" />
+            Win Rate
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={loading}
+            onClick={() => setActiveTab('roi')}
+            className={`flex items-center gap-1 ${activeTab === 'roi' ? 'active tab-button' : ''}`}
+          >
+            <DollarSign className="w-4 h-4" />
+            ROI
+          </Button>
         </div>
 
 
@@ -167,8 +234,8 @@ export default function Leaderboard() {
         </div>
         )}
 
-        {/* Full Leaderboard Table */}
-        {!loading && leaderboardData.length > 0 && (
+        {/* Reputation Leaderboard Table */}
+        {!loading && activeTab === 'reputation' && leaderboardData.length > 0 && (
         <div className="glass-card overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full">
@@ -195,7 +262,7 @@ export default function Leaderboard() {
                 </tr>
               </thead>
               <tbody>
-                {leaderboardData.map((entry, index) => (
+                {leaderboardData.map((entry) => (
                   <tr
                     key={entry.address}
                     className="border-b border-border/50 hover:bg-muted/20 transition-colors"
@@ -235,6 +302,160 @@ export default function Leaderboard() {
                     </td>
                   </tr>
                 ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        )}
+
+        {/* Win Rate Leaders Table */}
+        {!loading && activeTab === 'winrate' && (
+        <div className="glass-card overflow-hidden">
+          {mostAccurate && (
+            <div className="px-6 py-4 border-b border-border bg-warning/5 flex items-center gap-3">
+              <Award className="w-5 h-5 text-warning" />
+              <span className="text-sm font-medium">
+                Most Accurate Trader:{' '}
+                <span className="text-warning">
+                  {mostAccurate.username || mostAccurate.walletAddress}
+                </span>{' '}
+                — {mostAccurate.winRate}% win rate ({mostAccurate.totalPredictions} trades)
+              </span>
+            </div>
+          )}
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="text-left py-4 px-6 font-semibold">
+                    <Hash className="w-4 h-4 inline mr-2" />
+                    Rank
+                  </th>
+                  <th className="text-left py-4 px-6 font-semibold">Trader</th>
+                  <th className="text-right py-4 px-6 font-semibold">
+                    <Target className="w-4 h-4 inline mr-2" />
+                    Win Rate
+                  </th>
+                  <th className="text-right py-4 px-6 font-semibold hidden md:table-cell">Wins</th>
+                  <th className="text-right py-4 px-6 font-semibold hidden md:table-cell">Total</th>
+                  <th className="text-right py-4 px-6 font-semibold hidden lg:table-cell">
+                    <Star className="w-4 h-4 inline mr-2" />
+                    Level
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {winRateLeaders.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="py-10 text-center text-muted-foreground">
+                      No data yet — traders need at least 5 predictions to appear here.
+                    </td>
+                  </tr>
+                ) : (
+                  winRateLeaders.map((entry) => (
+                    <tr
+                      key={entry.walletAddress}
+                      className="border-b border-border/50 hover:bg-muted/20 transition-colors"
+                    >
+                      <td className="py-4 px-6">
+                        <span className={`font-bold ${rankColors[entry.rank] || 'text-foreground'}`}>
+                          #{entry.rank}
+                        </span>
+                      </td>
+                      <td className="py-4 px-6">
+                        <div className="font-medium">
+                          {entry.username || entry.walletAddress}
+                        </div>
+                      </td>
+                      <td className="py-4 px-6 text-right">
+                        <span className={entry.winRate >= 60 ? 'text-success font-bold' : entry.winRate >= 50 ? 'text-foreground' : 'text-destructive'}>
+                          {entry.winRate}%
+                        </span>
+                      </td>
+                      <td className="py-4 px-6 text-right hidden md:table-cell text-success">
+                        {entry.successfulPredictions}
+                      </td>
+                      <td className="py-4 px-6 text-right hidden md:table-cell">
+                        {entry.totalPredictions}
+                      </td>
+                      <td className="py-4 px-6 text-right hidden lg:table-cell">
+                        <Badge variant="outline" className="text-xs">{entry.level}</Badge>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        )}
+
+        {/* ROI Leaders Table */}
+        {!loading && activeTab === 'roi' && (
+        <div className="glass-card overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="text-left py-4 px-6 font-semibold">
+                    <Hash className="w-4 h-4 inline mr-2" />
+                    Rank
+                  </th>
+                  <th className="text-left py-4 px-6 font-semibold">Trader</th>
+                  <th className="text-right py-4 px-6 font-semibold">
+                    <DollarSign className="w-4 h-4 inline mr-2" />
+                    ROI
+                  </th>
+                  <th className="text-right py-4 px-6 font-semibold hidden md:table-cell">P&amp;L</th>
+                  <th className="text-right py-4 px-6 font-semibold hidden md:table-cell">Volume</th>
+                  <th className="text-right py-4 px-6 font-semibold hidden lg:table-cell">
+                    <Star className="w-4 h-4 inline mr-2" />
+                    Level
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {roiLeaders.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="py-10 text-center text-muted-foreground">
+                      No ROI data available yet.
+                    </td>
+                  </tr>
+                ) : (
+                  roiLeaders.map((entry) => (
+                    <tr
+                      key={entry.walletAddress}
+                      className="border-b border-border/50 hover:bg-muted/20 transition-colors"
+                    >
+                      <td className="py-4 px-6">
+                        <span className={`font-bold ${rankColors[entry.rank] || 'text-foreground'}`}>
+                          #{entry.rank}
+                        </span>
+                      </td>
+                      <td className="py-4 px-6">
+                        <div className="font-medium">
+                          {entry.username || entry.walletAddress}
+                        </div>
+                      </td>
+                      <td className="py-4 px-6 text-right">
+                        <span className={`font-bold ${(entry.roi ?? 0) >= 0 ? 'text-success' : 'text-destructive'}`}>
+                          {(entry.roi ?? 0) >= 0 ? '+' : ''}{entry.roi?.toFixed(2)}%
+                        </span>
+                      </td>
+                      <td className="py-4 px-6 text-right hidden md:table-cell">
+                        <span className={`${(entry.profitLoss ?? 0) >= 0 ? 'text-success' : 'text-destructive'}`}>
+                          {(entry.profitLoss ?? 0) >= 0 ? '+' : ''}{entry.profitLoss?.toFixed(2)}
+                        </span>
+                      </td>
+                      <td className="py-4 px-6 text-right hidden md:table-cell">
+                        {entry.totalVolume?.toFixed(2)}
+                      </td>
+                      <td className="py-4 px-6 text-right hidden lg:table-cell">
+                        <Badge variant="outline" className="text-xs">{entry.level}</Badge>
+                      </td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
           </div>

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -404,6 +404,14 @@ export const leaderboardService = {
     return response.data!;
   },
 
+  async getAdvancedMetrics(limit = 20): Promise<any> {
+    const response = await apiClient.get(`${ENDPOINTS.LEADERBOARD_ADVANCED}?limit=${limit}`);
+    if (!response.success) {
+      throw new Error(response.message || 'Failed to fetch advanced leaderboard metrics');
+    }
+    return response.data;
+  },
+
   async getLeaderboard(params?: { limit?: number; timeframe?: string }): Promise<any> {
     const queryParams = new URLSearchParams();
     if (params) {

--- a/frontend/src/services/pushNotificationService.ts
+++ b/frontend/src/services/pushNotificationService.ts
@@ -1,0 +1,81 @@
+import { apiClient } from '@/lib/api-client';
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  return Uint8Array.from([...raw].map((c) => c.charCodeAt(0)));
+}
+
+async function getVapidPublicKey(): Promise<string | null> {
+  try {
+    const res = await apiClient.get<{ publicKey: string }>('/push/vapid-public-key');
+    return res.success ? res.data!.publicKey : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getOrRegisterServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!('serviceWorker' in navigator)) return null;
+  try {
+    const existing = await navigator.serviceWorker.getRegistration('/sw.js');
+    if (existing) return existing;
+    return await navigator.serviceWorker.register('/sw.js');
+  } catch {
+    return null;
+  }
+}
+
+export async function subscribeToPushNotifications(authToken: string): Promise<boolean> {
+  if (!('Notification' in window) || !('PushManager' in window)) return false;
+
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') return false;
+
+  const vapidKey = await getVapidPublicKey();
+  if (!vapidKey) return false;
+
+  const registration = await getOrRegisterServiceWorker();
+  if (!registration) return false;
+
+  try {
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidKey),
+    });
+
+    apiClient.setAuthToken(authToken);
+    const res = await apiClient.post('/push/subscribe', { subscription });
+    return res.success === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function unsubscribeFromPushNotifications(authToken: string): Promise<boolean> {
+  const registration = await navigator.serviceWorker?.getRegistration('/sw.js');
+  if (!registration) return false;
+
+  try {
+    const subscription = await registration.pushManager.getSubscription();
+    if (subscription) await subscription.unsubscribe();
+
+    apiClient.setAuthToken(authToken);
+    const res = await apiClient.delete('/push/subscribe');
+    return res.success === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isPushSubscribed(): Promise<boolean> {
+  const registration = await navigator.serviceWorker?.getRegistration('/sw.js');
+  if (!registration) return false;
+  const sub = await registration.pushManager.getSubscription().catch(() => null);
+  return !!sub;
+}
+
+export function isPushSupported(): boolean {
+  return 'Notification' in window && 'PushManager' in window && 'serviceWorker' in navigator;
+}


### PR DESCRIPTION
## Summary

This PR addresses four open issues to improve security, reliability, and user experience across the Oryn Finance platform.

---

### #82 — Add Environment Validation on Startup

**Problem:** Missing or misconfigured environment variables caused silent runtime failures or unexpected crashes deep into app startup.

**Changes:**
- Added `backend/src/config/envValidator.js` — validates all critical env vars (`JWT_SECRET`, `MONGODB_URI`) before any server setup runs. Required vars that are missing or invalid abort startup with a clear error message; optional vars emit a startup warning via the existing Winston logger.
- `JWT_SECRET` and `MONGODB_URI` are marked **required**; `NODE_ENV`, `PORT`, `FRONTEND_URL` are validated with warnings on misconfiguration.
- `.env.example` updated to mark `JWT_SECRET` as required with a minimum-length hint.
- `validateEnv()` is the first call inside `OrynBackendServer.initialize()`, before DB connection or any middleware.

---

### #81 — Add API Abuse Detection Middleware

**Problem:** Existing rate limiting (express-rate-limit) caps raw request volume but does not detect or block sustained suspicious patterns.

**Changes:**
- Added `backend/src/middleware/abuseDetection.js` — a sliding-window, in-memory per-IP tracker.
  - **60 req/min** → logs a `warn`-level abuse pattern alert via Winston.
  - **100 req/min** → automatically blocks the IP for **15 minutes**, returning `429` with a `retryAfter` field.
  - Blocked IPs are checked first on every request for zero-overhead fast-path rejection.
  - A periodic cleanup interval purges stale windows and expired blocks to prevent memory growth.
- `detectAbuse` is mounted **before** the existing `express-rate-limit` on all `/api/` routes, so both layers are active.
- All abuse events (suspicious pattern, block, blocked-IP attempt) are logged with IP, path, method, and count via `logger.warn`.

---

### #80 — Add Browser Push Notifications

**Problem:** Users miss important market events (trade confirmations, market resolutions) when they are not actively viewing the app.

**Changes:**

**Backend:**
- Added `backend/src/services/pushNotificationService.js` — wraps `web-push` (VAPID). Provides `notifyTradeExecuted` and `notifyMarketResolved` helpers; gracefully degrades (logs a warning) if VAPID keys are not configured.
- Added `backend/src/routes/pushNotifications.js` with three endpoints:
  - `GET /api/push/vapid-public-key` — returns the server's VAPID public key.
  - `POST /api/push/subscribe` (auth required) — saves a push subscription for the authenticated wallet.
  - `DELETE /api/push/subscribe` (auth required) — removes the subscription.
- VAPID init is called once at server startup (`initVapid()`).
- `.env.example` documents `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` with a generation hint.

**Frontend:**
- Added `frontend/public/sw.js` — service worker that handles `push` events and `notificationclick`, showing native OS notifications with click-to-navigate.
- Added `frontend/src/services/pushNotificationService.ts` — subscribes/unsubscribes via `PushManager`, fetches the VAPID key from the backend, and posts the subscription object to the API.
- Added `frontend/src/hooks/usePushNotifications.ts` — React hook encapsulating subscribe/unsubscribe state and loading.
- Added `frontend/src/components/NotificationPreferences.tsx` — a self-contained toggle button (Bell / BellOff) that can be dropped into any settings surface. Hidden automatically when Push is not supported in the browser.

---

### #79 — Add Advanced Leaderboard Metrics

**Problem:** The leaderboard only surfaced reputation scores; win rate and ROI insights were unavailable, and the "most accurate trader" could not be identified.

**Changes:**

**Backend:**
- Added `LeaderboardController.getAdvancedMetrics` — a single endpoint returning three datasets:
  - `winRateLeaders` — users with ≥ 5 predictions, sorted by `winRate` descending.
  - `roiLeaders` — users with volume > 0, ROI computed as `(profitLoss / totalVolume) × 100`, sorted descending.
  - `mostAccurateTrader` — single top user with ≥ 10 predictions, returned with a `badge: 'most-accurate-trader'` field.
- Registered as `GET /api/leaderboard/advanced-metrics` (optional auth) in the leaderboard router.

**Frontend:**
- `ENDPOINTS.LEADERBOARD_ADVANCED` added to `api-config.ts`.
- `apiService.leaderboard.getAdvancedMetrics()` added to `apiService.ts`.
- `Leaderboard.tsx` now fetches both reputation and advanced data in parallel (`Promise.allSettled`) — reputation failures do not block advanced data and vice versa.
- Three-tab switcher added (**Reputation** / **Win Rate** / **ROI**), each with its own appropriately-columned table.
- The Win Rate tab features a pinned "Most Accurate Trader" banner with the `Award` badge when data is available.
- Empty states are shown per-tab when minimum thresholds are not yet met.

---

## Files Changed

| Path | Change |
|---|---|
| `backend/src/config/envValidator.js` | New — startup env validation |
| `backend/src/middleware/abuseDetection.js` | New — sliding-window abuse detection |
| `backend/src/routes/pushNotifications.js` | New — push subscribe/unsubscribe routes |
| `backend/src/services/pushNotificationService.js` | New — web-push VAPID service |
| `backend/src/controllers/leaderboardController.js` | Extended — `getAdvancedMetrics` |
| `backend/src/routes/leaderboard.js` | Extended — `/advanced-metrics` route |
| `backend/server.js` | Wired env validator, abuse middleware, push route & service |
| `backend/.env.example` | Documented new required/optional vars |
| `frontend/public/sw.js` | New — service worker for push events |
| `frontend/src/services/pushNotificationService.ts` | New — subscribe/unsubscribe logic |
| `frontend/src/hooks/usePushNotifications.ts` | New — React hook |
| `frontend/src/components/NotificationPreferences.tsx` | New — toggle UI component |
| `frontend/src/pages/Leaderboard.tsx` | Extended — Win Rate & ROI tabs, advanced fetch |
| `frontend/src/services/apiService.ts` | Extended — `getAdvancedMetrics` |
| `frontend/src/lib/api-config.ts` | Extended — new endpoints |

---

Closes #79
Closes #80
Closes #81
Closes #82