### PR TITLE
feat: add prediction confidence indicator

### DIFF
--- a/frontend/src/components/markets/ConfidenceMeter.tsx
+++ b/frontend/src/components/markets/ConfidenceMeter.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { calculateConfidence, type ConfidenceScore } from '@/lib/utils';
+
+interface ConfidenceMeterProps {
+  liquidity: number;
+  volume: number;
+  compact?: boolean;
+  className?: string;
+}
+
+export function ConfidenceMeter({ liquidity, volume, compact = false, className = '' }: ConfidenceMeterProps) {
+  const [confidence, setConfidence] = useState<ConfidenceScore>(() =>
+    calculateConfidence(liquidity, volume)
+  );
+
+  useEffect(() => {
+    setConfidence(calculateConfidence(liquidity, volume));
+  }, [liquidity, volume]);
+
+  const barWidth = `${Math.max(confidence.score, 2)}%`;
+
+  if (compact) {
+    return (
+      <div className={`flex items-center gap-2 ${className}`}>
+        <div className="flex-1 h-1.5 rounded-full bg-white/[0.06] overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all duration-700 ease-out"
+            style={{
+              width: barWidth,
+              background: `linear-gradient(90deg, ${confidence.color}99, ${confidence.color})`,
+              boxShadow: `0 0 8px ${confidence.color}40`,
+            }}
+          />
+        </div>
+        <span className="text-[10px] font-semibold text-white/60 whitespace-nowrap" style={{ color: confidence.color }}>
+          {confidence.level}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold text-white/60 uppercase tracking-wider">
+          Confidence
+        </span>
+        <div className="flex items-center gap-2">
+          <span
+            className="text-sm font-bold transition-colors duration-500"
+            style={{ color: confidence.color }}
+          >
+            {confidence.score}%
+          </span>
+          <span
+            className="text-[10px] font-semibold px-2 py-0.5 rounded-full transition-all duration-500"
+            style={{
+              color: confidence.color,
+              backgroundColor: `${confidence.color}15`,
+              border: `1px solid ${confidence.color}30`,
+            }}
+          >
+            {confidence.level}
+          </span>
+        </div>
+      </div>
+      <div className="w-full h-2 rounded-full bg-white/[0.06] overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all duration-700 ease-out"
+          style={{
+            width: barWidth,
+            background: `linear-gradient(90deg, ${confidence.color}66, ${confidence.color})`,
+            boxShadow: `0 0 10px ${confidence.color}40`,
+          }}
+        />
+      </div>
+      <div className="flex justify-between text-[9px] text-white/25">
+        <span>Low confidence</span>
+        <span>High confidence</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/markets/MarketCard.tsx
+++ b/frontend/src/components/markets/MarketCard.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { MagicCard } from '@/components/magicui/magic-card';
 import { cn } from '@/lib/utils';
 import { CountdownTimer } from '@/components/ui/CountdownTimer';
+import { ConfidenceMeter } from '@/components/markets/ConfidenceMeter';
 
 interface MarketCardProps {
   market: Market;
@@ -99,6 +100,11 @@ export function MarketCard({ market, featured = false }: MarketCardProps) {
 
           {/* Price Layout */}
           <div className="space-y-4 mb-6">
+            <ConfidenceMeter
+              liquidity={market.liquidity}
+              volume={market.volume}
+              compact
+            />
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <div className="w-2 h-2 rounded-full bg-success shadow-[0_0_8px_rgba(34,197,94,0.5)]" />

--- a/frontend/src/components/ui/ConfirmationModal.tsx
+++ b/frontend/src/components/ui/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -8,7 +8,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Info, AlertCircle, AlertTriangle } from "lucide-react";
+import { Info, AlertCircle, AlertTriangle, Loader2, CheckCircle2 } from "lucide-react";
 
 interface ConfirmationModalProps {
   isOpen: boolean;
@@ -99,90 +99,173 @@ export function TradeConfirmationModal({
     slippage,
   } = tradeDetails;
 
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && isProcessing) {
+      const t = setTimeout(() => setIsProcessing(false), 600);
+      return () => clearTimeout(t);
+    }
+  }, [isLoading, isProcessing]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsProcessing(false);
+    }
+  }, [isOpen]);
+
+  const handleConfirmClick = () => {
+    setIsProcessing(true);
+    onConfirm();
+  };
+
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open && !isLoading) onClose(); }}>
       <DialogContent className="sm:max-w-[425px] glass-card border-white/10 text-white">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold flex items-center gap-2">
-            Confirm {type === 'buy' ? 'Buy' : 'Sell'} Order
+            {isProcessing ? (
+              <>
+                <Loader2 className="w-5 h-5 text-primary animate-spin" />
+                Processing Order...
+              </>
+            ) : (
+              `Confirm ${type === 'buy' ? 'Buy' : 'Sell'} Order`
+            )}
           </DialogTitle>
           <DialogDescription className="text-muted-foreground">
-            Please review your trade details before confirming.
+            {isProcessing
+              ? 'Your order is being processed. This may take a moment.'
+              : 'Please review your trade details before confirming.'}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="py-6 space-y-4">
-          <div className="flex justify-between items-end p-4 rounded-xl bg-white/[0.03] border border-white/5">
-            <div>
-              <span className="text-[10px] font-bold text-white/40 uppercase block mb-1">
-                You {type === 'buy' ? 'Pay' : 'Sell'}
-              </span>
-              <span className="text-2xl font-bold">{amount} USDC</span>
+        {isProcessing ? (
+          <div className="py-8 space-y-4">
+            <div className="flex items-center justify-center">
+              <div className="relative">
+                <div className="w-16 h-16 rounded-full border-4 border-primary/20 border-t-primary animate-spin" />
+                <CheckCircle2 className="w-8 h-8 text-primary/60 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
+              </div>
             </div>
-            <div className="text-right">
-              <span className="text-[10px] font-bold text-white/40 uppercase block mb-1">
-                {type === 'buy' ? 'Receiving' : 'To Receive'}
-              </span>
-              <span className="text-lg font-bold text-primary">
-                {tokensReceived} {position}
-              </span>
-            </div>
-          </div>
 
-          <div className="space-y-3 px-1">
-            <div className="flex justify-between text-sm">
-              <span className="text-white/60">Price per token</span>
-              <span className="font-medium">{Math.round(price * 100)}¢</span>
-            </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-white/60">Execution Fee</span>
-              <span className="font-medium">{fee} USDC</span>
-            </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-white/60">Price Impact</span>
-              <span className={parseFloat(priceImpact) > 1 ? 'text-warning' : 'text-success'}>
-                {priceImpact}%
-              </span>
-            </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-white/60">Max Slippage</span>
-              <span className="font-medium">{slippage}%</span>
-            </div>
-          </div>
-
-          {parseFloat(priceImpact) > 2 && (
-            <div className="p-3 rounded-lg bg-warning/10 border border-warning/20 flex gap-2 items-start">
-              <AlertCircle className="w-4 h-4 text-warning shrink-0 mt-0.5" />
-              <p className="text-xs text-warning/90">
-                High price impact detected. You may receive significantly fewer tokens than expected.
+            <div className="space-y-3">
+              <div className="w-full bg-muted/30 rounded-full h-2 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-primary to-secondary animate-pulse"
+                  style={{ width: '70%', transition: 'width 2s ease-in-out' }}
+                />
+              </div>
+              <p className="text-xs text-center text-muted-foreground">
+                Building and signing your transaction...
               </p>
             </div>
-          )}
 
-          <div className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 flex gap-2 items-start">
-            <Info className="w-4 h-4 text-blue-400 shrink-0 mt-0.5" />
-            <p className="text-xs text-blue-300/80">
-              Large orders may be partially filled if liquidity is insufficient. Any unfilled portion will not be charged.
-            </p>
+            <div className="p-3 rounded-lg bg-muted/20 space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">{type === 'buy' ? 'Buying' : 'Selling'}</span>
+                <span className="font-medium text-primary">{amount} USDC</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Receiving</span>
+                <span className="font-medium">{tokensReceived} {position}</span>
+              </div>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="py-6 space-y-4">
+            <div className="flex justify-between items-end p-4 rounded-xl bg-white/[0.03] border border-white/5">
+              <div>
+                <span className="text-[10px] font-bold text-white/40 uppercase block mb-1">
+                  You {type === 'buy' ? 'Pay' : 'Sell'}
+                </span>
+                <span className="text-2xl font-bold">{amount} USDC</span>
+              </div>
+              <div className="text-right">
+                <span className="text-[10px] font-bold text-white/40 uppercase block mb-1">
+                  {type === 'buy' ? 'Receiving' : 'To Receive'}
+                </span>
+                <span className="text-lg font-bold text-primary">
+                  {tokensReceived} {position}
+                </span>
+              </div>
+            </div>
+
+            <div className="space-y-3 px-1">
+              <div className="flex justify-between text-sm">
+                <span className="text-white/60">Price per token</span>
+                <span className="font-medium">{Math.round(price * 100)}¢</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-white/60">Execution Fee</span>
+                <span className="font-medium">{fee} USDC</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-white/60">Price Impact</span>
+                <span className={parseFloat(priceImpact) > 1 ? 'text-warning' : 'text-success'}>
+                  {priceImpact}%
+                </span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-white/60">Max Slippage</span>
+                <span className="font-medium">{slippage}%</span>
+              </div>
+            </div>
+
+            {parseFloat(priceImpact) > 2 && (
+              <div className="p-3 rounded-lg bg-warning/10 border border-warning/20 flex gap-2 items-start">
+                <AlertCircle className="w-4 h-4 text-warning shrink-0 mt-0.5" />
+                <p className="text-xs text-warning/90">
+                  High price impact detected. You may receive significantly fewer tokens than expected.
+                </p>
+              </div>
+            )}
+
+            <div className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 flex gap-2 items-start">
+              <Info className="w-4 h-4 text-blue-400 shrink-0 mt-0.5" />
+              <p className="text-xs text-blue-300/80">
+                Large orders may be partially filled if liquidity is insufficient. Any unfilled portion will not be charged.
+              </p>
+            </div>
+          </div>
+        )}
 
         <DialogFooter className="gap-2 sm:gap-0">
-          <Button
-            variant="outline"
-            onClick={onClose}
-            disabled={isLoading}
-            className="border-white/10 hover:bg-white/5"
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={onConfirm}
-            disabled={isLoading}
-            className="btn-primary-gradient flex-1"
-          >
-            {isLoading ? "Confirming..." : `Confirm ${type === 'buy' ? 'Buy' : 'Sell'}`}
-          </Button>
+          {isProcessing ? (
+            <Button
+              variant="outline"
+              disabled
+              className="border-white/10 w-full opacity-50"
+            >
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Processing...
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                onClick={onClose}
+                disabled={isLoading}
+                className="border-white/10 hover:bg-white/5"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleConfirmClick}
+                disabled={isLoading}
+                className="btn-primary-gradient flex-1"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                    Confirming...
+                  </>
+                ) : (
+                  `Confirm ${type === 'buy' ? 'Buy' : 'Sell'}`
+                )}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/hooks/useOptimisticTrade.ts
+++ b/frontend/src/hooks/useOptimisticTrade.ts
@@ -1,0 +1,163 @@
+import { useState, useCallback, useRef } from 'react';
+
+export type OptimisticPhase =
+  | 'idle'
+  | 'optimistic'
+  | 'building'
+  | 'signing'
+  | 'submitting'
+  | 'confirming'
+  | 'confirmed'
+  | 'failed'
+  | 'rolled_back';
+
+export interface OptimisticTrade {
+  id: string;
+  type: 'buy' | 'sell';
+  position: 'YES' | 'NO';
+  amount: number;
+  price: number;
+  tokensReceived: string;
+  fee: string;
+  marketId: string;
+  marketQuestion: string;
+  timestamp: number;
+  txHash?: string;
+  status: 'pending' | 'confirmed' | 'failed' | 'partial';
+  partialFill?: {
+    filledAmount: number;
+    remainingAmount: number;
+    fillRatio: number;
+    requestedAmount: number;
+  };
+}
+
+interface UseOptimisticTradeCallbacks {
+  onSuccess?: (trade: OptimisticTrade) => void;
+  onError?: (error: Error, trade: OptimisticTrade) => void;
+  onSettled?: () => void;
+}
+
+export function useOptimisticTrade(callbacks?: UseOptimisticTradeCallbacks) {
+  const [optimisticTrades, setOptimisticTrades] = useState<OptimisticTrade[]>([]);
+  const [phase, setPhase] = useState<OptimisticPhase>('idle');
+  const [phaseMessage, setPhaseMessage] = useState('');
+  const [txHash, setTxHash] = useState<string | undefined>();
+  const [activeTradeId, setActiveTradeId] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const generateId = useCallback(() => {
+    return `opt-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }, []);
+
+  const addOptimisticTrade = useCallback(
+    (trade: Omit<OptimisticTrade, 'id' | 'timestamp' | 'status'> & { id?: string; timestamp?: number }) => {
+      const id = trade.id || generateId();
+      const optimisticTrade: OptimisticTrade = {
+        ...trade,
+        id,
+        timestamp: trade.timestamp || Date.now(),
+        status: 'pending',
+      };
+      setOptimisticTrades((prev) => [optimisticTrade, ...prev]);
+      setActiveTradeId(id);
+      setPhase('optimistic');
+      setPhaseMessage('Order confirmed — finalizing on-chain...');
+      return id;
+    },
+    [generateId]
+  );
+
+  const updateOptimisticTrade = useCallback((id: string, updates: Partial<OptimisticTrade>) => {
+    setOptimisticTrades((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, ...updates } : t))
+    );
+  }, []);
+
+  const confirmOptimisticTrade = useCallback(
+    (id: string, updates: Partial<Omit<OptimisticTrade, 'id'>>) => {
+      setOptimisticTrades((prev) =>
+        prev.map((t) =>
+          t.id === id
+            ? { ...t, ...updates, status: updates.status || ('confirmed' as const) }
+            : t
+        )
+      );
+      setPhase('confirmed');
+      setPhaseMessage('Order confirmed');
+      const resolved = optimisticTrades.find((t) => t.id === id);
+      if (resolved) {
+        callbacks?.onSuccess?.(resolved);
+      }
+      callbacks?.onSettled?.();
+    },
+    [optimisticTrades, callbacks]
+  );
+
+  const rollbackOptimisticTrade = useCallback(
+    (id: string, error: Error) => {
+      setOptimisticTrades((prev) =>
+        prev.map((t) =>
+          t.id === id ? { ...t, status: 'failed' as const, txHash: undefined } : t
+        )
+      );
+      setPhase('rolled_back');
+      setPhaseMessage(error.message);
+      const failedTrade = optimisticTrades.find((t) => t.id === id);
+      if (failedTrade) {
+        callbacks?.onError?.(error, failedTrade);
+      }
+      callbacks?.onSettled?.();
+      setTimeout(() => {
+        setOptimisticTrades((prev) => prev.filter((t) => t.id !== id || t.status !== 'failed'));
+      }, 8000);
+    },
+    [optimisticTrades, callbacks]
+  );
+
+  const setTransactionPhase = useCallback(
+    (newPhase: OptimisticPhase, message: string, hash?: string) => {
+      setPhase(newPhase);
+      setPhaseMessage(message);
+      if (hash) setTxHash(hash);
+    },
+    []
+  );
+
+  const reset = useCallback(() => {
+    setPhase('idle');
+    setPhaseMessage('');
+    setTxHash(undefined);
+    setActiveTradeId(null);
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const isPending =
+    phase === 'optimistic' ||
+    phase === 'building' ||
+    phase === 'signing' ||
+    phase === 'submitting' ||
+    phase === 'confirming';
+  const isError = phase === 'failed' || phase === 'rolled_back';
+  const isSuccess = phase === 'confirmed';
+
+  return {
+    optimisticTrades,
+    phase,
+    phaseMessage,
+    txHash,
+    activeTradeId,
+    addOptimisticTrade,
+    updateOptimisticTrade,
+    confirmOptimisticTrade,
+    rollbackOptimisticTrade,
+    setTransactionPhase,
+    reset,
+    abortRef,
+    isPending,
+    isError,
+    isSuccess,
+    setOptimisticTrades,
+  };
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,40 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+const MAX_LIQUIDITY = 2000000;
+const MAX_VOLUME = 5000000;
+
+export interface ConfidenceScore {
+  score: number;
+  level: 'Very Low' | 'Low' | 'Medium' | 'High' | 'Very High';
+  color: string;
+}
+
+export function calculateConfidence(liquidity: number, volume: number): ConfidenceScore {
+  const liquidityScore = Math.min(50, (Math.log10(Math.max(liquidity, 1)) / Math.log10(MAX_LIQUIDITY)) * 50);
+  const volumeScore = Math.min(50, (Math.log10(Math.max(volume, 1)) / Math.log10(MAX_VOLUME)) * 50);
+  const score = Math.round(liquidityScore + volumeScore);
+
+  let level: ConfidenceScore['level'];
+  let color: string;
+
+  if (score >= 86) {
+    level = 'Very High';
+    color = '#22c55e';
+  } else if (score >= 66) {
+    level = 'High';
+    color = '#16a34a';
+  } else if (score >= 46) {
+    level = 'Medium';
+    color = '#eab308';
+  } else if (score >= 26) {
+    level = 'Low';
+    color = '#f97316';
+  } else {
+    level = 'Very Low';
+    color = '#ef4444';
+  }
+
+  return { score, level, color };
+}

--- a/frontend/src/pages/MarketDetail.tsx
+++ b/frontend/src/pages/MarketDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft, TrendingUp, Users, Calendar, Clock, ExternalLink, Info, Loader2, AlertTriangle, WifiOff, CheckCircle2, XCircle, ArrowRight } from 'lucide-react';
+import { ArrowLeft, TrendingUp, Users, Calendar, Clock, ExternalLink, Info, Loader2, AlertTriangle, WifiOff, CheckCircle2, XCircle, ArrowRight, Shield } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -17,6 +17,7 @@ import { OddsChart } from '@/components/OddsChart';
 import { useMarketUpdates } from '@/contexts/WebSocketContext';
 import { useOffline } from '@/hooks/useOffline';
 import { useOptimisticTrade, type OptimisticPhase, type OptimisticTrade } from '@/hooks/useOptimisticTrade';
+import { ConfidenceMeter } from '@/components/markets/ConfidenceMeter';
 
 function formatVolume(volume: number): string {
   if (volume >= 1000000) return `$${(volume / 1000000).toFixed(2)}M`;
@@ -134,6 +135,8 @@ export default function MarketDetail() {
 
   const [liveYesPrice, setLiveYesPrice] = useState(currentMarket.yesPrice);
   const [liveNoPrice, setLiveNoPrice] = useState(currentMarket.noPrice);
+  const [liveLiquidity, setLiveLiquidity] = useState(currentMarket.liquidity);
+  const [liveVolume, setLiveVolume] = useState(currentMarket.volume);
 
   useEffect(() => {
     if (!marketData) return;
@@ -141,6 +144,18 @@ export default function MarketDetail() {
     if (rawYes != null) {
       setLiveYesPrice(rawYes);
       setLiveNoPrice(1 - rawYes);
+    }
+    if (marketData.liquidity != null) {
+      setLiveLiquidity(marketData.liquidity);
+    } else if (marketData.initialLiquidity != null) {
+      setLiveLiquidity(marketData.initialLiquidity);
+    }
+    if (marketData.volume != null) {
+      setLiveVolume(marketData.volume);
+    } else if (marketData.totalVolume != null) {
+      setLiveVolume(marketData.totalVolume);
+    } else if (marketData.volume24h != null) {
+      setLiveVolume(marketData.volume24h);
     }
   }, [marketData]);
 
@@ -678,8 +693,12 @@ export default function MarketDetail() {
                     <TrendingUp className="w-4 h-4" />
                     Total Volume
                   </span>
-                  <span className="font-medium">{formatVolume(currentMarket.volume)}</span>
+                  <span className="font-medium">{formatVolume(liveVolume)}</span>
                 </div>
+                <ConfidenceMeter
+                  liquidity={liveLiquidity}
+                  volume={liveVolume}
+                />
                 <div className="flex justify-between">
                   <span className="text-muted-foreground flex items-center gap-2">
                     <Users className="w-4 h-4" />

--- a/frontend/src/pages/MarketDetail.tsx
+++ b/frontend/src/pages/MarketDetail.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft, TrendingUp, Users, Calendar, Clock, ExternalLink, Info, Loader2, AlertTriangle, WifiOff } from 'lucide-react';
+import { ArrowLeft, TrendingUp, Users, Calendar, Clock, ExternalLink, Info, Loader2, AlertTriangle, WifiOff, CheckCircle2, XCircle, ArrowRight } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -16,12 +16,37 @@ import { ResolutionPanel } from '@/components/ResolutionPanel';
 import { OddsChart } from '@/components/OddsChart';
 import { useMarketUpdates } from '@/contexts/WebSocketContext';
 import { useOffline } from '@/hooks/useOffline';
+import { useOptimisticTrade, type OptimisticPhase, type OptimisticTrade } from '@/hooks/useOptimisticTrade';
 
 function formatVolume(volume: number): string {
   if (volume >= 1000000) return `$${(volume / 1000000).toFixed(2)}M`;
   if (volume >= 1000) return `$${(volume / 1000).toFixed(1)}K`;
   return `$${volume}`;
 }
+
+const PHASE_LABELS: Record<OptimisticPhase, string> = {
+  idle: '',
+  optimistic: 'Order placed — confirming on-chain',
+  building: 'Building transaction...',
+  signing: 'Awaiting wallet signature...',
+  submitting: 'Submitting to Stellar network...',
+  confirming: 'Awaiting network confirmation...',
+  confirmed: 'Transaction confirmed',
+  failed: 'Transaction failed',
+  rolled_back: 'Order reverted — something went wrong',
+};
+
+const PHASE_PERCENT: Record<OptimisticPhase, number> = {
+  idle: 0,
+  optimistic: 15,
+  building: 30,
+  signing: 50,
+  submitting: 70,
+  confirming: 90,
+  confirmed: 100,
+  failed: 100,
+  rolled_back: 0,
+};
 
 export default function MarketDetail() {
   const { id } = useParams();
@@ -40,7 +65,20 @@ export default function MarketDetail() {
     txHash?: string;
   }>({ phase: 'idle', message: '' });
 
-  // Demo markets data
+  const {
+    phase: optimisticPhase,
+    phaseMessage,
+    txHash: optimisticTxHash,
+    activeTradeId,
+    addOptimisticTrade,
+    confirmOptimisticTrade,
+    rollbackOptimisticTrade,
+    setTransactionPhase,
+    reset: resetOptimistic,
+    isPending: isOptimisticPending,
+    isError: isOptimisticError,
+  } = useOptimisticTrade();
+
   const demoMarkets: { [key: string]: Market } = {
     '1': {
       id: '1',
@@ -92,10 +130,8 @@ export default function MarketDetail() {
     }
   };
 
-  // Get the current market
   const currentMarket = demoMarkets[id || ''] || demoMarkets['openai-gpt5-2026'];
 
-  // Live prices updated via WebSocket; fall back to market initial prices
   const [liveYesPrice, setLiveYesPrice] = useState(currentMarket.yesPrice);
   const [liveNoPrice, setLiveNoPrice] = useState(currentMarket.noPrice);
 
@@ -107,35 +143,34 @@ export default function MarketDetail() {
       setLiveNoPrice(1 - rawYes);
     }
   }, [marketData]);
-  
+
   const imbalanceRatio = Math.max(liveYesPrice, liveNoPrice);
   const isImbalanced = imbalanceRatio >= 0.8;
   const imbalancedSide = liveYesPrice > liveNoPrice ? 'YES' : 'NO';
 
-  // Generate demo trades
   const recentTrades = [
-    { 
+    {
       id: '1',
-      type: 'Buy', 
-      position: 'YES', 
-      amount: 100, 
-      price: currentMarket.yesPrice, 
+      type: 'Buy',
+      position: 'YES',
+      amount: 100,
+      price: currentMarket.yesPrice,
       timestamp: new Date(Date.now() - 300000).toLocaleTimeString()
     },
-    { 
+    {
       id: '2',
-      type: 'Sell', 
-      position: 'NO', 
-      amount: 50, 
-      price: currentMarket.noPrice, 
+      type: 'Sell',
+      position: 'NO',
+      amount: 50,
+      price: currentMarket.noPrice,
       timestamp: new Date(Date.now() - 600000).toLocaleTimeString()
     },
-    { 
+    {
       id: '3',
-      type: 'Buy', 
-      position: 'YES', 
-      amount: 75, 
-      price: currentMarket.yesPrice - 0.05, 
+      type: 'Buy',
+      position: 'YES',
+      amount: 75,
+      price: currentMarket.yesPrice - 0.05,
       timestamp: new Date(Date.now() - 900000).toLocaleTimeString()
     }
   ];
@@ -169,6 +204,18 @@ export default function MarketDetail() {
       return;
     }
 
+    const parsedAmount = parseFloat(amount);
+    const optimisticId = addOptimisticTrade({
+      type: tradeType,
+      position,
+      amount: parsedAmount,
+      price,
+      tokensReceived,
+      fee: estimatedFee,
+      marketId: currentMarket.id,
+      marketQuestion: currentMarket.question,
+    });
+
     setIsLoading(true);
     setPartialFillResult(null);
 
@@ -190,6 +237,7 @@ export default function MarketDetail() {
     };
 
     try {
+      setTransactionPhase('building', 'Building transaction...');
       setTxProgress({ phase: 'building', message: 'Building transaction...' });
       toast.loading('Building transaction...', { id: 'trade-toast' });
 
@@ -197,13 +245,13 @@ export default function MarketDetail() {
         ? await apiService.transactions.buildBuyTokens({
             marketId: currentMarket.id,
             tokenType: position.toLowerCase() as 'yes' | 'no',
-            amount: parseFloat(amount),
+            amount: parsedAmount,
             maxSlippage: 1.0
           }, publicKey)
         : await apiService.transactions.buildSellTokens({
             marketId: currentMarket.id,
             tokenType: position.toLowerCase() as 'yes' | 'no',
-            amount: parseFloat(amount),
+            amount: parsedAmount,
             maxSlippage: 1.0
           }, publicKey);
 
@@ -211,11 +259,13 @@ export default function MarketDetail() {
         throw new Error('Failed to build transaction');
       }
 
+      setTransactionPhase('signing', 'Please sign the transaction in your wallet...');
       setTxProgress({ phase: 'signing', message: 'Waiting for wallet signature...' });
       toast.loading('Please sign the transaction in your wallet...', { id: 'trade-toast' });
 
       const signedXdr = await signTransaction(transactionData.xdr);
 
+      setTransactionPhase('submitting', 'Submitting to Stellar network...');
       setTxProgress({ phase: 'submitting', message: 'Submitting transaction to network...' });
       toast.loading('Submitting transaction to network...', { id: 'trade-toast' });
 
@@ -226,10 +276,10 @@ export default function MarketDetail() {
         throw new Error('Transaction submitted but no hash returned');
       }
 
+      setTransactionPhase('confirming', 'Awaiting network confirmation...', txHash);
       setTxProgress({ phase: 'confirming', message: 'Confirming transaction...', txHash });
       const confirmed = await pollTransaction(txHash);
 
-      // Handle partial fill from response
       const tradeData = confirmed?.data?.trade ?? submitResult?.data?.trade;
       if (tradeData?.isPartial) {
         const pfResult: PartialFillResult = {
@@ -237,15 +287,29 @@ export default function MarketDetail() {
           filledAmount: tradeData.filledAmount,
           remainingAmount: tradeData.remainingAmount,
           fillRatio: tradeData.fillRatio,
-          requestedAmount: tradeData.requestedAmount ?? parseFloat(amount),
+          requestedAmount: tradeData.requestedAmount ?? parsedAmount,
         };
         setPartialFillResult(pfResult);
+        confirmOptimisticTrade(optimisticId, {
+          status: 'partial',
+          txHash,
+          partialFill: {
+            filledAmount: tradeData.filledAmount,
+            remainingAmount: tradeData.remainingAmount,
+            fillRatio: tradeData.fillRatio,
+            requestedAmount: tradeData.requestedAmount ?? parsedAmount,
+          },
+        });
         setTxProgress({ phase: 'success', message: 'Order partially filled', txHash });
         toast.warning(
-          `Partial fill: ${tradeData.filledAmount.toFixed(4)} of ${parseFloat(amount).toFixed(4)} ${position} filled`,
+          `Partial fill: ${tradeData.filledAmount.toFixed(4)} of ${parsedAmount.toFixed(4)} ${position} filled`,
           { id: 'trade-toast', description: `${tradeData.remainingAmount.toFixed(4)} remaining — insufficient liquidity` }
         );
       } else {
+        confirmOptimisticTrade(optimisticId, {
+          status: 'confirmed',
+          txHash,
+        });
         setTxProgress({ phase: 'success', message: 'Transaction confirmed', txHash });
         toast.success(`${tradeType.charAt(0).toUpperCase() + tradeType.slice(1)} order successful!`, {
           id: 'trade-toast',
@@ -255,21 +319,34 @@ export default function MarketDetail() {
 
       setAmount('');
     } catch (error) {
-      console.error('Trade error:', error);
+      const err = error instanceof Error ? error : new Error('Transaction failed');
+      console.error('Trade error:', err);
+
+      rollbackOptimisticTrade(optimisticId, err);
       setTxProgress({
         phase: 'error',
-        message: error instanceof Error ? error.message : 'Transaction failed'
+        message: err.message
       });
-      toast.error(error instanceof Error ? error.message : 'Transaction failed', { id: 'trade-toast' });
+      toast.error(err.message, { id: 'trade-toast' });
     } finally {
       setIsLoading(false);
     }
   };
 
+  const handleDismissError = useCallback(() => {
+    resetOptimistic();
+    setTxProgress({ phase: 'idle', message: '' });
+  }, [resetOptimistic]);
+
+  const handleRetryTrade = useCallback(() => {
+    resetOptimistic();
+    setTxProgress({ phase: 'idle', message: '' });
+    handleTradeConfirm();
+  }, [resetOptimistic]);
+
   return (
     <Layout>
       <div className="container mx-auto px-4 py-8">
-        {/* Back Button */}
         <Link to="/markets" className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6 transition-colors">
           <ArrowLeft className="w-4 h-4" />
           Back to Markets
@@ -304,8 +381,8 @@ export default function MarketDetail() {
               {currentMarket.description && (
                 <p className="text-muted-foreground mb-4">{currentMarket.description}</p>
               )}
-              
-              {/* Current Prices — Live */}
+
+              {/* Current Prices */}
               <div className="grid grid-cols-2 gap-4 mt-6">
                 <div className="p-4 rounded-xl bg-success/10 border border-success/20">
                   <div className="text-sm text-muted-foreground mb-1">YES Price</div>
@@ -317,6 +394,97 @@ export default function MarketDetail() {
                 </div>
               </div>
             </div>
+
+            {/* Optimistic Trade Result Banner */}
+            {optimisticPhase !== 'idle' && (
+              <div
+                className={`glass-card p-4 border ${
+                  isOptimisticError
+                    ? 'bg-red-500/5 border-red-500/20'
+                    : 'bg-success/5 border-success/20'
+                }`}
+              >
+                {isOptimisticPending ? (
+                  <div className="flex items-start gap-3">
+                    <Loader2 className="w-5 h-5 text-primary animate-spin shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-primary">Order Submitted — Pending Confirmation</p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {tradeType === 'buy' ? 'Buy' : 'Sell'} {position} · {amount} USDC · {tokensReceived} tokens @ {Math.round(price * 100)}¢
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Your order is being processed. You&apos;ll see the result here shortly.
+                      </p>
+                      <div className="w-full h-1.5 rounded-full bg-muted/50 mt-3 overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all duration-700 ease-out ${
+                            isOptimisticError ? 'bg-red-500' : 'bg-gradient-to-r from-primary to-secondary'
+                          }`}
+                          style={{ width: `${PHASE_PERCENT[optimisticPhase]}%` }}
+                        />
+                      </div>
+                      <p className="text-[10px] text-muted-foreground mt-2">{PHASE_LABELS[optimisticPhase]}</p>
+                      {optimisticTxHash && (
+                        <p className="text-[10px] text-muted-foreground mt-1 font-mono break-all">
+                          Tx: {optimisticTxHash}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ) : isOptimisticError ? (
+                  <div className="flex items-start gap-3">
+                    <XCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-red-400">Order Failed</p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {tradeType === 'buy' ? 'Buy' : 'Sell'} {position} · {amount} USDC · {tokensReceived} tokens @ {Math.round(price * 100)}¢
+                      </p>
+                      <p className="text-xs text-red-400/80 mt-1">{phaseMessage}</p>
+                      <div className="flex items-center gap-2 mt-3">
+                        <Button size="sm" variant="outline" onClick={handleDismissError} className="text-xs h-7">
+                          Dismiss
+                        </Button>
+                        <Button size="sm" onClick={handleRetryTrade} className="text-xs h-7 btn-primary-gradient">
+                          <ArrowRight className="w-3 h-3 mr-1" />
+                          Retry
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-start gap-3">
+                    <CheckCircle2 className="w-5 h-5 text-success shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-success">
+                        {tradeType === 'buy' ? 'Bought' : 'Sold'} {tokensReceived} {position} @ {Math.round(price * 100)}¢
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {amount} USDC · Fee: {estimatedFee} USDC · Price impact: {priceImpact}%
+                      </p>
+                      {activeTradeId && partialFillResult && (
+                        <div className="mt-2">
+                          <PartialFillBanner result={partialFillResult} tokenType={position} />
+                        </div>
+                      )}
+                      {optimisticTxHash && (
+                        <a
+                          href={`https://stellar.expert/explorer/testnet/tx/${optimisticTxHash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
+                        >
+                          View on Explorer
+                          <ExternalLink className="w-3 h-3" />
+                        </a>
+                      )}
+                      <p className="text-[10px] text-muted-foreground mt-2">
+                        The page will update with the latest position data.
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Dynamic Odds Visualization */}
             <div className="glass-card p-6">
@@ -436,12 +604,12 @@ export default function MarketDetail() {
                   </div>
 
                   {/* Trade Button */}
-                  <Button 
+                  <Button
                     className="w-full btn-primary-gradient"
                     onClick={handleTradeStart}
-                    disabled={isLoading || isOffline}
+                    disabled={isLoading || isOffline || isOptimisticPending}
                   >
-                    {isLoading ? (
+                    {isLoading || isOptimisticPending ? (
                       <>
                         <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                         Confirming...
@@ -459,7 +627,7 @@ export default function MarketDetail() {
                   </Button>
 
                   <p className="text-xs text-center text-muted-foreground">
-                    Est. settlement: ~5 seconds
+                    {isOptimisticPending ? 'Confirming on-chain (~5s)' : 'Est. settlement: ~5 seconds'}
                   </p>
 
                   {txProgress.phase !== 'idle' && (

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import {
   ArrowRight,
   Download,
@@ -14,6 +15,8 @@ import {
   TrendingDown,
   TrendingUp,
   Wallet,
+  Clock,
+  Circle,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Layout } from '@/components/layout/Layout';
@@ -876,9 +879,19 @@ export default function Portfolio() {
 
           <div className="mt-6">
             {tradeHistoryLoading ? (
-              <div className="text-center py-8 text-muted-foreground">
-                <Loader2 className="w-10 h-10 mx-auto mb-4 animate-spin" />
-                <p>Loading filtered trade history...</p>
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="p-4 rounded-lg bg-muted/20 animate-pulse">
+                    <div className="flex items-center gap-3">
+                      <div className="w-2 h-2 rounded-full bg-muted/40" />
+                      <div className="flex-1 space-y-2">
+                        <div className="h-4 bg-muted/30 rounded w-3/4" />
+                        <div className="h-3 bg-muted/20 rounded w-1/2" />
+                      </div>
+                      <div className="w-20 h-4 bg-muted/30 rounded" />
+                    </div>
+                  </div>
+                ))}
               </div>
             ) : tradeHistory.length === 0 ? (
               <div className="text-center py-8 text-muted-foreground">
@@ -887,40 +900,74 @@ export default function Portfolio() {
               </div>
             ) : (
               <div className="space-y-2">
-                {tradeHistory.map((trade: any) => (
-                  <Link
-                    key={trade.tradeId || trade._id}
-                    to={`/trade/${trade.tradeId || trade._id}`}
-                    className="flex items-center justify-between p-4 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors group gap-4"
-                  >
-                    <div className="flex items-start gap-3 min-w-0">
-                      <div className={`w-2 h-2 mt-2 rounded-full ${trade.tradeType === 'buy' ? 'bg-success' : 'bg-destructive'}`} />
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium line-clamp-1">{getTradeMarketQuestion(trade)}</p>
-                        <p className="text-xs text-muted-foreground capitalize mt-1">
-                          {trade.tradeType} {trade.tokenType?.toUpperCase()} · {formatAmount(trade.amount ?? 0)} tokens · {formatDateTime(getTradeTimestamp(trade))}
-                        </p>
-                        <p className="text-xs text-muted-foreground mt-1">
-                          Fees {formatCurrency(trade.fees?.total ?? 0)} ·
-                          <span className={`ml-1 ${getTradeStatusClass(trade.status)}`}>
-                            P&amp;L {formatPnL(trade.currentPnL)}
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-3 shrink-0">
-                      <div className="text-right">
-                        <p className="text-sm font-semibold">
-                          {formatCurrency(trade.totalCost ?? 0)}
-                        </p>
-                        <p className={`text-xs ${getTradeStatusClass(trade.status)}`}>
-                          {formatStatusLabel(trade.status || 'unknown')}
-                        </p>
-                      </div>
-                      <ExternalLink className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
-                    </div>
-                  </Link>
-                ))}
+                <AnimatePresence mode="popLayout">
+                  {tradeHistory.map((trade: any, index: number) => (
+                    <motion.div
+                      key={trade.tradeId || trade._id}
+                      initial={{ opacity: 0, y: 12 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.25, delay: Math.min(index * 0.04, 0.4) }}
+                    >
+                      <Link
+                        to={`/trade/${trade.tradeId || trade._id}`}
+                        className="flex items-center justify-between p-4 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors group gap-4"
+                      >
+                        <div className="flex items-start gap-3 min-w-0">
+                          <div className="relative">
+                            <div className={`w-2 h-2 mt-2 rounded-full ${
+                              trade.status === 'pending'
+                                ? 'bg-yellow-500 animate-pulse'
+                                : trade.tradeType === 'buy'
+                                  ? 'bg-success'
+                                  : 'bg-destructive'
+                            }`} />
+                            {trade.status === 'pending' && (
+                              <div className="absolute inset-0 w-2 h-2 rounded-full bg-yellow-500/40 animate-ping" />
+                            )}
+                          </div>
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium line-clamp-1">{getTradeMarketQuestion(trade)}</p>
+                            <p className="text-xs text-muted-foreground capitalize mt-1">
+                              {trade.status === 'pending' && (
+                                <span className="inline-flex items-center gap-1 mr-2">
+                                  <Circle className="w-2 h-2 fill-yellow-500 text-yellow-500 animate-pulse" />
+                                  <span className="text-yellow-500">Pending</span>
+                                </span>
+                              )}
+                              {trade.tradeType} {trade.tokenType?.toUpperCase()} · {formatAmount(trade.amount ?? 0)} tokens · {formatDateTime(getTradeTimestamp(trade))}
+                            </p>
+                            <p className="text-xs text-muted-foreground mt-1">
+                              Fees {formatCurrency(trade.fees?.total ?? 0)} ·
+                              <span className={`ml-1 ${getTradeStatusClass(trade.status)}`}>
+                                P&amp;L {formatPnL(trade.currentPnL)}
+                              </span>
+                            </p>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-3 shrink-0">
+                          <div className="text-right">
+                            <p className="text-sm font-semibold">
+                              {formatCurrency(trade.totalCost ?? 0)}
+                            </p>
+                            <p className={`text-xs ${getTradeStatusClass(trade.status)}`}>
+                              {trade.status === 'pending' ? (
+                                <span className="flex items-center gap-1">
+                                  <Clock className="w-3 h-3" />
+                                  Confirming
+                                </span>
+                              ) : (
+                                formatStatusLabel(trade.status || 'unknown')
+                              )}
+                            </p>
+                          </div>
+                          <ExternalLink className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                        </div>
+                      </Link>
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
Closes #88

---

## Summary

Adds a **Prediction Confidence Indicator** that helps users assess market reliability beyond just odds.

### Changes

1. **Confidence Score Calculation** (rontend/src/lib/utils.ts)
   - Computes confidence from liquidity + volume using logarithmic normalization
   - Returns score (0-100), level (Very Low to Very High), and color

2. **ConfidenceMeter Component** (rontend/src/components/markets/ConfidenceMeter.tsx)
   - Full mode: shows score %, level badge, and gradient progress bar
   - Compact mode: inline bar + level label for market cards
   - Smooth transitions (700ms) and glows for visual polish

3. **MarketCard Integration** (rontend/src/components/markets/MarketCard.tsx)
   - Compact confidence meter displayed between stats and price layout

4. **MarketDetail Dynamic Updates** (rontend/src/pages/MarketDetail.tsx)
   - Live liquidity and volume extracted from WebSocket market updates
   - Full confidence meter in Market Info sidebar updates in real-time