### PR TITLE
Add i18n language support

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import IntegrationTest from "./components/IntegrationTest";
 import { RabetWalletTest } from "./components/RabetWalletTest";
 import { OfflineBanner } from "@/components/OfflineBanner";
 import { useOffline } from "@/hooks/useOffline";
+import { I18nProvider } from "@/i18n";
 
 const queryClient = new QueryClient();
 
@@ -61,9 +62,10 @@ function AppShell() {
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <WalletProvider>
-      <WebSocketProvider>
-        <TooltipProvider>
+    <I18nProvider>
+      <WalletProvider>
+        <WebSocketProvider>
+          <TooltipProvider>
           <Toaster />
           <Sonner />
           <HotToaster />
@@ -89,9 +91,10 @@ const App = () => (
               <Route path="*" element={<NotFound />} />
             </Routes>
           </BrowserRouter>
-        </TooltipProvider>
-      </WebSocketProvider>
-    </WalletProvider>
+          </TooltipProvider>
+        </WebSocketProvider>
+      </WalletProvider>
+    </I18nProvider>
   </QueryClientProvider>
 );
 

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -5,22 +5,24 @@ import { WalletSelector } from '@/components/WalletSelector';
 import { WalletBalance } from '@/components/wallet/WalletBalance';
 import { CompactWalletBalance } from '@/components/wallet/CompactWalletBalance';
 import { useWallet } from '@/contexts/WalletContext';
+import { useI18n } from '@/i18n';
 
 const navItems = [
-  { name: 'Home', path: '/' },
-  { name: 'Markets', path: '/markets' },
-  { name: 'Liquidity', path: '/liquidity' },
-  { name: 'Create', path: '/create' },
-  { name: 'About', path: '/about' },
-  { name: 'Leaderboard', path: '/leaderboard' },
-  { name: 'Analytics', path: '/analytics' },
-  { name: 'Governance', path: '/governance' },
+  { labelKey: 'nav.home', path: '/' },
+  { labelKey: 'nav.markets', path: '/markets' },
+  { labelKey: 'nav.liquidity', path: '/liquidity' },
+  { labelKey: 'nav.create', path: '/create' },
+  { labelKey: 'nav.about', path: '/about' },
+  { labelKey: 'nav.leaderboard', path: '/leaderboard' },
+  { labelKey: 'nav.analytics', path: '/analytics' },
+  { labelKey: 'nav.governance', path: '/governance' },
 ];
 
 export function Navbar() {
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { isConnected, publicKey } = useWallet();
+  const { language, languages, languageNames, setLanguage, t } = useI18n();
 
   const adminAddresses = (import.meta.env.VITE_ADMIN_ADDRESSES || '').split(',').map((a: string) => a.trim().toLowerCase());
   const isAdmin = isConnected && publicKey && (
@@ -48,13 +50,26 @@ export function Navbar() {
                   location.pathname === item.path ? 'text-primary' : 'text-neutral-400'
                 }`}
               >
-                {item.name}
+                {t(item.labelKey)}
               </Link>
             ))}
           </div>
 
           {/* Wallet Section */}
           <div className="flex gap-2 items-center flex-shrink-0">
+            <label className="sr-only" htmlFor="language-select">{t('language.label')}</label>
+            <select
+              id="language-select"
+              value={language}
+              onChange={(event) => setLanguage(event.target.value as typeof language)}
+              className="hidden sm:block h-9 rounded-full border border-white/10 bg-black/30 px-3 text-xs text-white outline-none transition-colors hover:bg-white/5"
+            >
+              {languages.map((lang) => (
+                <option key={lang} value={lang} className="bg-black text-white">
+                  {languageNames[lang]}
+                </option>
+              ))}
+            </select>
             {isAdmin && (
               <Link
                 to="/admin"
@@ -90,7 +105,7 @@ export function Navbar() {
         <div className="fixed inset-0 z-[60] bg-black/95 backdrop-blur-xl animate-fade-in">
           <div className="flex flex-col h-full">
             <div className="flex items-center justify-between px-6 py-6 border-b border-white/10">
-              <span className="text-xl font-bold">Menu</span>
+              <span className="text-xl font-bold">{t('nav.menu')}</span>
               <button onClick={() => setMobileMenuOpen(false)} className="p-2 text-white">
                 <X className="w-6 h-6" />
               </button>
@@ -111,7 +126,7 @@ export function Navbar() {
                     }`}
                   onClick={() => setMobileMenuOpen(false)}
                 >
-                  {item.name}
+                  {t(item.labelKey)}
                 </Link>
               ))}
               {isAdmin && (
@@ -124,7 +139,18 @@ export function Navbar() {
                 </Link>
               )}
               
-              <div className="mt-8">
+              <div className="mt-8 flex flex-col items-center gap-4">
+                <select
+                  value={language}
+                  onChange={(event) => setLanguage(event.target.value as typeof language)}
+                  className="h-10 rounded-full border border-white/10 bg-black/30 px-4 text-sm text-white outline-none"
+                >
+                  {languages.map((lang) => (
+                    <option key={lang} value={lang} className="bg-black text-white">
+                      {languageNames[lang]}
+                    </option>
+                  ))}
+                </select>
                 <WalletSelector />
               </div>
             </div>

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -1,0 +1,320 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+
+type Language = 'en' | 'es' | 'fr';
+
+type Dictionary = Record<string, string>;
+
+const STORAGE_KEY = 'oryn-language';
+
+const dictionaries: Record<Language, Dictionary> = {
+  en: {
+    'nav.home': 'Home',
+    'nav.markets': 'Markets',
+    'nav.create': 'Create',
+    'nav.liquidity': 'Liquidity',
+    'nav.about': 'About',
+    'nav.leaderboard': 'Leaderboard',
+    'nav.analytics': 'Analytics',
+    'nav.governance': 'Governance',
+    'nav.menu': 'Menu',
+    'language.label': 'Language',
+    'markets.trending': 'Trending Markets',
+    'markets.discover': 'Discover Markets',
+    'markets.cached': 'Cached',
+    'markets.offline': 'Offline',
+    'markets.refresh': 'Refresh',
+    'markets.subtitle': 'Browse and trade on {count} prediction markets',
+    'markets.search': 'Search by question or #tag...',
+    'markets.sort': 'Sort:',
+    'markets.endingSoon': 'Ending Soon',
+    'markets.noMarkets': 'No markets available',
+    'markets.noResults': 'No markets found matching your criteria',
+    'markets.clearFilters': 'Clear filters',
+    'market.back': 'Back to Markets',
+    'market.trending': 'Trending',
+    'market.liquidityImbalance': 'Liquidity Imbalance: {side} heavy',
+    'market.yesPrice': 'YES Price',
+    'market.noPrice': 'NO Price',
+    'market.performance': 'Market Performance',
+    'market.recentTrades': 'Recent Trades',
+    'market.buy': 'Buy',
+    'market.sell': 'Sell',
+    'market.amount': 'Amount (USDC)',
+    'market.receive': 'You receive',
+    'market.pricePerToken': 'Price per token',
+    'market.priceImpact': 'Est. price impact',
+    'market.fee': 'Est. fee',
+    'market.filled': 'Filled',
+    'market.remaining': 'Remaining',
+    'market.confirming': 'Confirming...',
+    'market.tradingDisabled': 'Offline - Trading Disabled',
+    'market.connectWallet': 'Connect Wallet',
+    'market.settlement': 'Est. settlement: ~5 seconds',
+    'market.txStatus': 'Transaction Status',
+    'market.sellPrompt': 'Connect wallet to view your positions to sell',
+    'market.info': 'Market Info',
+    'market.volume': 'Total Volume',
+    'market.traders': 'Traders',
+    'market.created': 'Created',
+    'market.expires': 'Expires',
+    'market.resolutionSource': 'Resolution Source',
+    'market.creator': 'Creator',
+    'create.title': 'Create a Market',
+    'create.subtitle': 'Launch your own prediction market and earn fees on every trade. Anyone can participate once your market goes live.',
+    'create.question': 'Market Question *',
+    'create.questionPlaceholder': 'Will Bitcoin exceed $150,000 by December 31, 2025?',
+    'create.characters': '{count}/{max} characters',
+    'create.category': 'Category *',
+    'create.selectCategory': 'Select a category',
+    'create.resolution': 'Resolution Source & Criteria *',
+    'create.resolutionPlaceholder': 'This market will resolve to YES if the official Bitcoin price on CoinGecko exceeds $150,000 at any point before the expiration date...',
+    'create.resolutionHelp': 'Be specific about what data source and conditions will determine the outcome',
+    'create.endDate': 'Market End Date *',
+    'create.pickDate': 'Pick a date',
+    'create.liquidity': 'Initial Liquidity (USDC) *',
+    'create.liquidityHelp': 'Minimum 50 USDC. Higher liquidity = better trading experience',
+    'create.tradingFee': 'Trading Fee',
+    'create.feeHelp': 'You earn this fee on every trade. Higher fees = more earnings but less trading volume',
+    'create.preview': 'Market Preview',
+    'create.previewQuestion': 'Your market question will appear here...',
+    'create.ends': 'Ends: {date}',
+    'create.notSet': 'Not set',
+    'create.costs': 'Estimated Costs',
+    'create.initialLiquidity': 'Initial Liquidity',
+    'create.networkFee': 'Network Fee',
+    'create.total': 'Total',
+    'create.important': 'Important',
+    'create.warning': 'Once created, markets cannot be edited. Make sure all information is accurate before proceeding.',
+    'create.status': 'Transaction Status',
+    'create.creating': 'Creating Market...',
+    'create.connect': 'Connect Wallet to Create',
+    'create.submit': 'Create Market',
+  },
+  es: {
+    'nav.home': 'Inicio',
+    'nav.markets': 'Mercados',
+    'nav.create': 'Crear',
+    'nav.liquidity': 'Liquidez',
+    'nav.about': 'Acerca de',
+    'nav.leaderboard': 'Clasificacion',
+    'nav.analytics': 'Analitica',
+    'nav.governance': 'Gobernanza',
+    'nav.menu': 'Menu',
+    'language.label': 'Idioma',
+    'markets.trending': 'Mercados en tendencia',
+    'markets.discover': 'Descubrir mercados',
+    'markets.cached': 'En cache',
+    'markets.offline': 'Sin conexion',
+    'markets.refresh': 'Actualizar',
+    'markets.subtitle': 'Explora y opera en {count} mercados de prediccion',
+    'markets.search': 'Buscar por pregunta o #etiqueta...',
+    'markets.sort': 'Ordenar:',
+    'markets.endingSoon': 'Terminan pronto',
+    'markets.noMarkets': 'No hay mercados disponibles',
+    'markets.noResults': 'No hay mercados que coincidan con tus criterios',
+    'markets.clearFilters': 'Limpiar filtros',
+    'market.back': 'Volver a mercados',
+    'market.trending': 'Tendencia',
+    'market.liquidityImbalance': 'Desequilibrio de liquidez: {side} dominante',
+    'market.yesPrice': 'Precio SI',
+    'market.noPrice': 'Precio NO',
+    'market.performance': 'Rendimiento del mercado',
+    'market.recentTrades': 'Operaciones recientes',
+    'market.buy': 'Comprar',
+    'market.sell': 'Vender',
+    'market.amount': 'Cantidad (USDC)',
+    'market.receive': 'Recibes',
+    'market.pricePerToken': 'Precio por token',
+    'market.priceImpact': 'Impacto est. en precio',
+    'market.fee': 'Comision est.',
+    'market.filled': 'Ejecutado',
+    'market.remaining': 'Restante',
+    'market.confirming': 'Confirmando...',
+    'market.tradingDisabled': 'Sin conexion - Trading desactivado',
+    'market.connectWallet': 'Conectar wallet',
+    'market.settlement': 'Liquidacion est.: ~5 segundos',
+    'market.txStatus': 'Estado de transaccion',
+    'market.sellPrompt': 'Conecta tu wallet para ver posiciones a vender',
+    'market.info': 'Info del mercado',
+    'market.volume': 'Volumen total',
+    'market.traders': 'Traders',
+    'market.created': 'Creado',
+    'market.expires': 'Expira',
+    'market.resolutionSource': 'Fuente de resolucion',
+    'market.creator': 'Creador',
+    'create.title': 'Crear un mercado',
+    'create.subtitle': 'Lanza tu propio mercado de prediccion y gana comisiones en cada operacion. Cualquiera puede participar cuando este activo.',
+    'create.question': 'Pregunta del mercado *',
+    'create.questionPlaceholder': 'Bitcoin superara $150,000 antes del 31 de diciembre de 2025?',
+    'create.characters': '{count}/{max} caracteres',
+    'create.category': 'Categoria *',
+    'create.selectCategory': 'Selecciona una categoria',
+    'create.resolution': 'Fuente y criterios de resolucion *',
+    'create.resolutionPlaceholder': 'Este mercado resolvera SI si el precio oficial de Bitcoin en CoinGecko supera $150,000 antes de la fecha de expiracion...',
+    'create.resolutionHelp': 'Especifica que fuente de datos y condiciones determinaran el resultado',
+    'create.endDate': 'Fecha de cierre *',
+    'create.pickDate': 'Elegir fecha',
+    'create.liquidity': 'Liquidez inicial (USDC) *',
+    'create.liquidityHelp': 'Minimo 50 USDC. Mas liquidez = mejor experiencia de trading',
+    'create.tradingFee': 'Comision de trading',
+    'create.feeHelp': 'Ganas esta comision en cada operacion. Comisiones mas altas = mas ingresos pero menos volumen',
+    'create.preview': 'Vista previa',
+    'create.previewQuestion': 'Tu pregunta aparecera aqui...',
+    'create.ends': 'Termina: {date}',
+    'create.notSet': 'No definido',
+    'create.costs': 'Costos estimados',
+    'create.initialLiquidity': 'Liquidez inicial',
+    'create.networkFee': 'Comision de red',
+    'create.total': 'Total',
+    'create.important': 'Importante',
+    'create.warning': 'Una vez creados, los mercados no se pueden editar. Verifica todo antes de continuar.',
+    'create.status': 'Estado de transaccion',
+    'create.creating': 'Creando mercado...',
+    'create.connect': 'Conectar wallet para crear',
+    'create.submit': 'Crear mercado',
+  },
+  fr: {
+    'nav.home': 'Accueil',
+    'nav.markets': 'Marches',
+    'nav.create': 'Creer',
+    'nav.liquidity': 'Liquidite',
+    'nav.about': 'A propos',
+    'nav.leaderboard': 'Classement',
+    'nav.analytics': 'Analytique',
+    'nav.governance': 'Gouvernance',
+    'nav.menu': 'Menu',
+    'language.label': 'Langue',
+    'markets.trending': 'Marches tendance',
+    'markets.discover': 'Decouvrir les marches',
+    'markets.cached': 'En cache',
+    'markets.offline': 'Hors ligne',
+    'markets.refresh': 'Actualiser',
+    'markets.subtitle': 'Parcourez et tradez sur {count} marches de prediction',
+    'markets.search': 'Rechercher par question ou #tag...',
+    'markets.sort': 'Trier:',
+    'markets.endingSoon': 'Bientot termines',
+    'markets.noMarkets': 'Aucun marche disponible',
+    'markets.noResults': 'Aucun marche ne correspond a vos criteres',
+    'markets.clearFilters': 'Effacer les filtres',
+    'market.back': 'Retour aux marches',
+    'market.trending': 'Tendance',
+    'market.liquidityImbalance': 'Desequilibre de liquidite: {side} dominant',
+    'market.yesPrice': 'Prix OUI',
+    'market.noPrice': 'Prix NON',
+    'market.performance': 'Performance du marche',
+    'market.recentTrades': 'Trades recents',
+    'market.buy': 'Acheter',
+    'market.sell': 'Vendre',
+    'market.amount': 'Montant (USDC)',
+    'market.receive': 'Vous recevez',
+    'market.pricePerToken': 'Prix par token',
+    'market.priceImpact': 'Impact prix est.',
+    'market.fee': 'Frais est.',
+    'market.filled': 'Execute',
+    'market.remaining': 'Restant',
+    'market.confirming': 'Confirmation...',
+    'market.tradingDisabled': 'Hors ligne - Trading desactive',
+    'market.connectWallet': 'Connecter wallet',
+    'market.settlement': 'Reglement est.: ~5 secondes',
+    'market.txStatus': 'Statut de transaction',
+    'market.sellPrompt': 'Connectez votre wallet pour voir vos positions a vendre',
+    'market.info': 'Infos marche',
+    'market.volume': 'Volume total',
+    'market.traders': 'Traders',
+    'market.created': 'Cree',
+    'market.expires': 'Expire',
+    'market.resolutionSource': 'Source de resolution',
+    'market.creator': 'Createur',
+    'create.title': 'Creer un marche',
+    'create.subtitle': 'Lancez votre propre marche de prediction et gagnez des frais sur chaque trade. Tout le monde peut participer une fois le marche actif.',
+    'create.question': 'Question du marche *',
+    'create.questionPlaceholder': 'Bitcoin depassera-t-il 150 000 $ avant le 31 decembre 2025 ?',
+    'create.characters': '{count}/{max} caracteres',
+    'create.category': 'Categorie *',
+    'create.selectCategory': 'Choisir une categorie',
+    'create.resolution': 'Source et criteres de resolution *',
+    'create.resolutionPlaceholder': 'Ce marche sera resolu OUI si le prix officiel du Bitcoin sur CoinGecko depasse 150 000 $ avant la date limite...',
+    'create.resolutionHelp': 'Precisez la source de donnees et les conditions qui determineront le resultat',
+    'create.endDate': 'Date de fin *',
+    'create.pickDate': 'Choisir une date',
+    'create.liquidity': 'Liquidite initiale (USDC) *',
+    'create.liquidityHelp': 'Minimum 50 USDC. Plus de liquidite = meilleure experience de trading',
+    'create.tradingFee': 'Frais de trading',
+    'create.feeHelp': 'Vous gagnez ces frais sur chaque trade. Frais plus eleves = plus de revenus mais moins de volume',
+    'create.preview': 'Apercu du marche',
+    'create.previewQuestion': 'Votre question apparaitra ici...',
+    'create.ends': 'Fin: {date}',
+    'create.notSet': 'Non defini',
+    'create.costs': 'Couts estimes',
+    'create.initialLiquidity': 'Liquidite initiale',
+    'create.networkFee': 'Frais reseau',
+    'create.total': 'Total',
+    'create.important': 'Important',
+    'create.warning': 'Une fois crees, les marches ne peuvent pas etre modifies. Verifiez tout avant de continuer.',
+    'create.status': 'Statut de transaction',
+    'create.creating': 'Creation du marche...',
+    'create.connect': 'Connecter wallet pour creer',
+    'create.submit': 'Creer le marche',
+  },
+};
+
+const languageNames: Record<Language, string> = {
+  en: 'English',
+  es: 'Espanol',
+  fr: 'Francais',
+};
+
+interface I18nContextValue {
+  language: Language;
+  languages: Language[];
+  languageNames: Record<Language, string>;
+  setLanguage: (language: Language) => void;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+function isLanguage(value: string | null): value is Language {
+  return value === 'en' || value === 'es' || value === 'fr';
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<Language>(() => {
+    if (typeof window === 'undefined') return 'en';
+    const storedLanguage = window.localStorage.getItem(STORAGE_KEY);
+    return isLanguage(storedLanguage) ? storedLanguage : 'en';
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, language);
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const value = useMemo<I18nContextValue>(() => {
+    const translate = (key: string, values: Record<string, string | number> = {}) => {
+      const template = dictionaries[language][key] ?? dictionaries.en[key] ?? key;
+      return Object.entries(values).reduce(
+        (result, [name, replacement]) => result.replaceAll(`{${name}}`, String(replacement)),
+        template
+      );
+    };
+
+    return {
+      language,
+      languages: ['en', 'es', 'fr'],
+      languageNames,
+      setLanguage: setLanguageState,
+      t: translate,
+    };
+  }, [language]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used within I18nProvider');
+  }
+  return context;
+}

--- a/frontend/src/pages/CreateMarket.tsx
+++ b/frontend/src/pages/CreateMarket.tsx
@@ -14,10 +14,12 @@ import { format } from 'date-fns';
 import { useWallet } from '@/contexts/WalletContext';
 import { apiService } from '@/services/apiService';
 import { toast } from 'sonner';
+import { useI18n } from '@/i18n';
 
 const categories = ['Crypto', 'Sports', 'Politics', 'Entertainment'];
 
 export default function CreateMarket() {
+  const { t } = useI18n();
   const navigate = useNavigate();
   const { isConnected, connect, publicKey, signTransaction } = useWallet();
   const [question, setQuestion] = useState('');
@@ -164,9 +166,9 @@ export default function CreateMarket() {
     <Layout>
       <div className="container mx-auto px-4 py-12 max-w-4xl">
         <div className="text-center mb-10">
-          <h1 className="text-3xl md:text-4xl font-bold mb-4">Create a Market</h1>
+          <h1 className="text-3xl md:text-4xl font-bold mb-4">{t('create.title')}</h1>
           <p className="text-muted-foreground max-w-xl mx-auto">
-            Launch your own prediction market and earn fees on every trade. Anyone can participate once your market goes live.
+            {t('create.subtitle')}
           </p>
         </div>
 
@@ -176,25 +178,25 @@ export default function CreateMarket() {
             <div className="glass-card p-6 space-y-6">
               {/* Question */}
               <div className="space-y-2">
-                <Label htmlFor="question">Market Question *</Label>
+                <Label htmlFor="question">{t('create.question')}</Label>
                 <Textarea
                   id="question"
-                  placeholder="Will Bitcoin exceed $150,000 by December 31, 2025?"
+                  placeholder={t('create.questionPlaceholder')}
                   value={question}
                   onChange={(e) => setQuestion(e.target.value.slice(0, maxChars))}
                   className="input-dark min-h-[100px]"
                 />
                 <p className={`text-xs ${charCount > maxChars - 20 ? 'text-warning' : 'text-muted-foreground'}`}>
-                  {charCount}/{maxChars} characters
+                  {t('create.characters', { count: charCount, max: maxChars })}
                 </p>
               </div>
 
               {/* Category */}
               <div className="space-y-2">
-                <Label>Category *</Label>
+                <Label>{t('create.category')}</Label>
                 <Select value={category} onValueChange={setCategory}>
                   <SelectTrigger className="input-dark">
-                    <SelectValue placeholder="Select a category" />
+                    <SelectValue placeholder={t('create.selectCategory')} />
                   </SelectTrigger>
                   <SelectContent>
                     {categories.map((cat) => (
@@ -206,23 +208,23 @@ export default function CreateMarket() {
 
               {/* Resolution Source */}
               <div className="space-y-2">
-                <Label htmlFor="resolution">Resolution Source & Criteria *</Label>
+                <Label htmlFor="resolution">{t('create.resolution')}</Label>
                 <Textarea
                   id="resolution"
-                  placeholder="This market will resolve to YES if the official Bitcoin price on CoinGecko exceeds $150,000 at any point before the expiration date..."
+                  placeholder={t('create.resolutionPlaceholder')}
                   value={resolutionSource}
                   onChange={(e) => setResolutionSource(e.target.value)}
                   className="input-dark min-h-[100px]"
                 />
                 <p className="text-xs text-muted-foreground flex items-start gap-1">
                   <Info className="w-3 h-3 mt-0.5 flex-shrink-0" />
-                  Be specific about what data source and conditions will determine the outcome
+                  {t('create.resolutionHelp')}
                 </p>
               </div>
 
               {/* End Date */}
               <div className="space-y-2">
-                <Label>Market End Date *</Label>
+                <Label>{t('create.endDate')}</Label>
                 <Popover>
                   <PopoverTrigger asChild>
                     <Button
@@ -230,7 +232,7 @@ export default function CreateMarket() {
                       className="w-full justify-start text-left font-normal input-dark"
                     >
                       <CalendarIcon className="mr-2 h-4 w-4" />
-                      {endDate ? format(endDate, 'PPP') : 'Pick a date'}
+                      {endDate ? format(endDate, 'PPP') : t('create.pickDate')}
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-auto p-0 bg-card border-border">
@@ -247,7 +249,7 @@ export default function CreateMarket() {
 
               {/* Initial Liquidity */}
               <div className="space-y-2">
-                <Label htmlFor="liquidity">Initial Liquidity (USDC) *</Label>
+                <Label htmlFor="liquidity">{t('create.liquidity')}</Label>
                 <Input
                   id="liquidity"
                   type="number"
@@ -257,14 +259,14 @@ export default function CreateMarket() {
                   className="input-dark"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Minimum 50 USDC. Higher liquidity = better trading experience
+                  {t('create.liquidityHelp')}
                 </p>
               </div>
 
               {/* Fee Percentage */}
               <div className="space-y-4">
                 <div className="flex justify-between">
-                  <Label>Trading Fee</Label>
+                  <Label>{t('create.tradingFee')}</Label>
                   <span className="text-sm font-medium">{feePercentage[0]}%</span>
                 </div>
                 <Slider
@@ -276,7 +278,7 @@ export default function CreateMarket() {
                   className="py-4"
                 />
                 <p className="text-xs text-muted-foreground">
-                  You earn this fee on every trade. Higher fees = more earnings but less trading volume
+                  {t('create.feeHelp')}
                 </p>
               </div>
             </div>
@@ -286,15 +288,15 @@ export default function CreateMarket() {
           <div className="lg:col-span-2 space-y-6">
             {/* Preview Card */}
             <div className="glass-card p-6">
-              <h3 className="font-semibold mb-4">Market Preview</h3>
+              <h3 className="font-semibold mb-4">{t('create.preview')}</h3>
               <div className="market-card">
                 <div className="flex items-center gap-2 mb-3">
                   <span className={`px-2 py-1 rounded text-xs ${category ? 'bg-primary/20 text-primary' : 'bg-muted text-muted-foreground'}`}>
-                    {category || 'Category'}
+                    {category || t('create.category').replace(' *', '')}
                   </span>
                 </div>
                 <p className="font-medium mb-4 line-clamp-3">
-                  {question || 'Your market question will appear here...'}
+                  {question || t('create.previewQuestion')}
                 </p>
                 <div className="grid grid-cols-2 gap-2 mb-4">
                   <div className="p-3 rounded-lg bg-success/10 text-center">
@@ -307,25 +309,25 @@ export default function CreateMarket() {
                   </div>
                 </div>
                 <div className="text-xs text-muted-foreground">
-                  Ends: {endDate ? format(endDate, 'PP') : 'Not set'}
+                  {t('create.ends', { date: endDate ? format(endDate, 'PP') : t('create.notSet') })}
                 </div>
               </div>
             </div>
 
             {/* Cost Summary */}
             <div className="glass-card p-6">
-              <h3 className="font-semibold mb-4">Estimated Costs</h3>
+              <h3 className="font-semibold mb-4">{t('create.costs')}</h3>
               <div className="space-y-3">
                 <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Initial Liquidity</span>
+                  <span className="text-muted-foreground">{t('create.initialLiquidity')}</span>
                   <span>${parseFloat(initialLiquidity) || 0} USDC</span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Network Fee</span>
+                  <span className="text-muted-foreground">{t('create.networkFee')}</span>
                   <span>~$0.01 XLM</span>
                 </div>
                 <div className="border-t border-border pt-3 flex justify-between font-semibold">
-                  <span>Total</span>
+                  <span>{t('create.total')}</span>
                   <span className="gradient-text">${estimatedCost.toFixed(2)}</span>
                 </div>
               </div>
@@ -335,16 +337,16 @@ export default function CreateMarket() {
             <div className="p-4 rounded-lg bg-warning/10 border border-warning/20 flex gap-3">
               <AlertCircle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
               <div className="text-sm">
-                <p className="font-medium text-warning">Important</p>
+                <p className="font-medium text-warning">{t('create.important')}</p>
                 <p className="text-muted-foreground mt-1">
-                  Once created, markets cannot be edited. Make sure all information is accurate before proceeding.
+                  {t('create.warning')}
                 </p>
               </div>
             </div>
 
             {txStatus.phase !== 'idle' && (
               <div className={`p-4 rounded-lg border ${txStatus.phase === 'error' ? 'bg-red-500/10 border-red-500/20' : 'bg-primary/10 border-primary/20'}`}>
-                <p className="text-sm font-medium mb-2">Transaction Status</p>
+                <p className="text-sm font-medium mb-2">{t('create.status')}</p>
                 <p className="text-xs text-muted-foreground mb-3">{txStatus.message}</p>
                 <div className="w-full h-2 rounded bg-muted/40 overflow-hidden">
                   <div
@@ -374,12 +376,12 @@ export default function CreateMarket() {
               {isCreating ? (
                 <>
                   <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                  Creating Market...
+                  {t('create.creating')}
                 </>
               ) : !isConnected ? (
-                'Connect Wallet to Create'
+                t('create.connect')
               ) : (
-                'Create Market'
+                t('create.submit')
               )}
             </Button>
           </div>

--- a/frontend/src/pages/MarketDetail.tsx
+++ b/frontend/src/pages/MarketDetail.tsx
@@ -16,6 +16,7 @@ import { ResolutionPanel } from '@/components/ResolutionPanel';
 import { OddsChart } from '@/components/OddsChart';
 import { useMarketUpdates } from '@/contexts/WebSocketContext';
 import { useOffline } from '@/hooks/useOffline';
+import { useI18n } from '@/i18n';
 
 function formatVolume(volume: number): string {
   if (volume >= 1000000) return `$${(volume / 1000000).toFixed(2)}M`;
@@ -24,6 +25,7 @@ function formatVolume(volume: number): string {
 }
 
 export default function MarketDetail() {
+  const { t } = useI18n();
   const { id } = useParams();
   const { isConnected, connect, publicKey, signTransaction } = useWallet();
   const { marketData } = useMarketUpdates(id || '');
@@ -272,7 +274,7 @@ export default function MarketDetail() {
         {/* Back Button */}
         <Link to="/markets" className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6 transition-colors">
           <ArrowLeft className="w-4 h-4" />
-          Back to Markets
+          {t('market.back')}
         </Link>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -287,7 +289,7 @@ export default function MarketDetail() {
                 {currentMarket.status === 'Trending' && (
                   <Badge className="bg-gradient-to-r from-primary to-secondary">
                     <TrendingUp className="w-3 h-3 mr-1" />
-                    Trending
+                    {t('market.trending')}
                   </Badge>
                 )}
               </div>
@@ -297,7 +299,7 @@ export default function MarketDetail() {
                 {isImbalanced && (
                   <Badge variant="outline" className="bg-warning/10 text-warning border-warning/20 flex items-center gap-1.5 animate-pulse">
                     <AlertTriangle className="w-3 h-3" />
-                    Liquidity Imbalance: {imbalancedSide} heavy
+                    {t('market.liquidityImbalance', { side: imbalancedSide })}
                   </Badge>
                 )}
               </div>
@@ -308,11 +310,11 @@ export default function MarketDetail() {
               {/* Current Prices — Live */}
               <div className="grid grid-cols-2 gap-4 mt-6">
                 <div className="p-4 rounded-xl bg-success/10 border border-success/20">
-                  <div className="text-sm text-muted-foreground mb-1">YES Price</div>
+                  <div className="text-sm text-muted-foreground mb-1">{t('market.yesPrice')}</div>
                   <div className="text-3xl font-bold text-success">{Math.round(liveYesPrice * 100)}¢</div>
                 </div>
                 <div className="p-4 rounded-xl bg-destructive/10 border border-destructive/20">
-                  <div className="text-sm text-muted-foreground mb-1">NO Price</div>
+                  <div className="text-sm text-muted-foreground mb-1">{t('market.noPrice')}</div>
                   <div className="text-3xl font-bold text-destructive">{Math.round(liveNoPrice * 100)}¢</div>
                 </div>
               </div>
@@ -320,7 +322,7 @@ export default function MarketDetail() {
 
             {/* Dynamic Odds Visualization */}
             <div className="glass-card p-6">
-              <h2 className="text-lg font-semibold mb-4">Market Performance</h2>
+              <h2 className="text-lg font-semibold mb-4">{t('market.performance')}</h2>
               <OddsChart
                 marketId={currentMarket.id}
                 initialYesPrice={currentMarket.yesPrice}
@@ -331,7 +333,7 @@ export default function MarketDetail() {
 
             {/* Recent Trades */}
             <div className="glass-card p-6">
-              <h2 className="text-lg font-semibold mb-4">Recent Trades</h2>
+              <h2 className="text-lg font-semibold mb-4">{t('market.recentTrades')}</h2>
               <div className="space-y-3">
                 {recentTrades.map((trade) => (
                   <div key={trade.id} className="flex items-center justify-between py-3 border-b border-border/50 last:border-0">
@@ -361,8 +363,8 @@ export default function MarketDetail() {
             <div className="glass-card p-6 sticky top-24">
               <Tabs value={tradeType} onValueChange={(v) => setTradeType(v as 'buy' | 'sell')}>
                 <TabsList className="grid w-full grid-cols-2 mb-4">
-                  <TabsTrigger value="buy">Buy</TabsTrigger>
-                  <TabsTrigger value="sell">Sell</TabsTrigger>
+                  <TabsTrigger value="buy">{t('market.buy')}</TabsTrigger>
+                  <TabsTrigger value="sell">{t('market.sell')}</TabsTrigger>
                 </TabsList>
 
                 <TabsContent value="buy" className="space-y-4">
@@ -386,7 +388,7 @@ export default function MarketDetail() {
 
                   {/* Amount Input */}
                   <div>
-                    <label className="text-sm text-muted-foreground mb-2 block">Amount (USDC)</label>
+                    <label className="text-sm text-muted-foreground mb-2 block">{t('market.amount')}</label>
                     <Input
                       type="number"
                       placeholder="0.00"
@@ -399,30 +401,30 @@ export default function MarketDetail() {
                   {/* Trade Summary */}
                   <div className="p-4 rounded-lg bg-muted/50 space-y-2">
                     <div className="flex justify-between text-sm">
-                      <span className="text-muted-foreground">You receive</span>
+                      <span className="text-muted-foreground">{t('market.receive')}</span>
                       <span className="font-medium">{tokensReceived} {position}</span>
                     </div>
                     <div className="flex justify-between text-sm">
-                      <span className="text-muted-foreground">Price per token</span>
+                      <span className="text-muted-foreground">{t('market.pricePerToken')}</span>
                       <span>{Math.round(price * 100)}¢</span>
                     </div>
                     <div className="flex justify-between text-sm">
-                      <span className="text-muted-foreground">Est. price impact</span>
+                      <span className="text-muted-foreground">{t('market.priceImpact')}</span>
                       <span className="text-warning">{priceImpact}%</span>
                     </div>
                     <div className="flex justify-between text-sm">
-                      <span className="text-muted-foreground">Est. fee</span>
+                      <span className="text-muted-foreground">{t('market.fee')}</span>
                       <span>{estimatedFee} USDC</span>
                     </div>
                     {partialFillResult && (
                       <>
                         <div className="border-t border-border/50 pt-2 mt-1" />
                         <div className="flex justify-between text-sm">
-                          <span className="text-success">Filled</span>
+                          <span className="text-success">{t('market.filled')}</span>
                           <span className="font-medium text-success">{partialFillResult.filledAmount.toFixed(4)} {position}</span>
                         </div>
                         <div className="flex justify-between text-sm">
-                          <span className="text-warning">Remaining</span>
+                          <span className="text-warning">{t('market.remaining')}</span>
                           <span className="font-medium text-warning">{partialFillResult.remainingAmount.toFixed(4)} {position}</span>
                         </div>
                         <div className="w-full h-1.5 rounded-full bg-white/10 overflow-hidden mt-1">
@@ -444,27 +446,27 @@ export default function MarketDetail() {
                     {isLoading ? (
                       <>
                         <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        Confirming...
+                        {t('market.confirming')}
                       </>
                     ) : isOffline ? (
                       <>
                         <WifiOff className="w-4 h-4 mr-2" />
-                        Offline — Trading Disabled
+                        {t('market.tradingDisabled')}
                       </>
                     ) : !isConnected ? (
-                      'Connect Wallet'
+                      t('market.connectWallet')
                     ) : (
                       `Buy ${position}`
                     )}
                   </Button>
 
                   <p className="text-xs text-center text-muted-foreground">
-                    Est. settlement: ~5 seconds
+                    {t('market.settlement')}
                   </p>
 
                   {txProgress.phase !== 'idle' && (
                     <div className={`p-3 rounded-lg border ${txProgress.phase === 'error' ? 'bg-red-500/10 border-red-500/20' : 'bg-primary/10 border-primary/20'}`}>
-                      <p className="text-xs font-medium mb-1">Transaction Status</p>
+                      <p className="text-xs font-medium mb-1">{t('market.txStatus')}</p>
                       <p className="text-xs text-muted-foreground">{txProgress.message}</p>
                       <div className="w-full h-1.5 rounded bg-muted/50 mt-2 overflow-hidden">
                         <div
@@ -492,7 +494,7 @@ export default function MarketDetail() {
 
                 <TabsContent value="sell" className="space-y-4">
                   <p className="text-center text-muted-foreground py-8">
-                    Connect wallet to view your positions to sell
+                    {t('market.sellPrompt')}
                   </p>
                 </TabsContent>
               </Tabs>
@@ -502,34 +504,34 @@ export default function MarketDetail() {
             <div className="glass-card p-6 space-y-4">
               <h3 className="font-semibold flex items-center gap-2">
                 <Info className="w-4 h-4" />
-                Market Info
+                {t('market.info')}
               </h3>
               <div className="space-y-3 text-sm">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground flex items-center gap-2">
                     <TrendingUp className="w-4 h-4" />
-                    Total Volume
+                    {t('market.volume')}
                   </span>
                   <span className="font-medium">{formatVolume(currentMarket.volume)}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground flex items-center gap-2">
                     <Users className="w-4 h-4" />
-                    Traders
+                    {t('market.traders')}
                   </span>
                   <span className="font-medium">{currentMarket.traders}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground flex items-center gap-2">
                     <Calendar className="w-4 h-4" />
-                    Created
+                    {t('market.created')}
                   </span>
                   <span className="font-medium">{new Date(currentMarket.createdAt).toLocaleDateString()}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground flex items-center gap-2">
                     <Clock className="w-4 h-4" />
-                    Expires
+                    {t('market.expires')}
                   </span>
                   <div className="text-right">
                     <div className="font-medium">{new Date(currentMarket.expirationDate).toLocaleDateString()}</div>
@@ -538,11 +540,11 @@ export default function MarketDetail() {
                 </div>
               </div>
               <div className="pt-4 border-t border-border">
-                <p className="text-xs text-muted-foreground mb-2">Resolution Source</p>
+                <p className="text-xs text-muted-foreground mb-2">{t('market.resolutionSource')}</p>
                 <p className="text-sm">{currentMarket.resolutionSource}</p>
               </div>
               <div className="pt-2">
-                <p className="text-xs text-muted-foreground mb-2">Creator</p>
+                <p className="text-xs text-muted-foreground mb-2">{t('market.creator')}</p>
                 <a href="#" className="text-sm text-primary flex items-center gap-1 hover:underline">
                   {currentMarket.creator}
                   <ExternalLink className="w-3 h-3" />

--- a/frontend/src/pages/Markets.tsx
+++ b/frontend/src/pages/Markets.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { apiService } from '@/services/apiService';
 import { Market } from '@/data/mockData';
 import { useOffline } from '@/hooks/useOffline';
+import { useI18n } from '@/i18n';
 
 type SortOption = 'volume' | 'newest' | 'ending';
 
@@ -54,6 +55,7 @@ const demoMarkets: Market[] = [
 ];
 
 export default function Markets() {
+  const { t } = useI18n();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string>('All');
   const [selectedStatus, setSelectedStatus] = useState<string>('All');
@@ -152,7 +154,7 @@ export default function Markets() {
           <div className="mb-12">
             <h2 className="text-2xl font-bold mb-6 flex items-center gap-2">
               <TrendingUp className="w-6 h-6 text-primary" />
-              Trending Markets
+              {t('markets.trending')}
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
               {trendingMarkets.map((market) => (
@@ -166,11 +168,11 @@ export default function Markets() {
         <div className="mb-8">
           <div className="flex items-center justify-between mb-2">
             <h1 className="text-3xl md:text-4xl font-bold flex items-center gap-3">
-              Discover Markets
+              {t('markets.discover')}
               {isCached && (
                 <Badge variant="outline" className="text-xs border-warning/40 text-warning bg-warning/10 flex items-center gap-1">
                   <WifiOff className="w-3 h-3" />
-                  Cached
+                  {t('markets.cached')}
                 </Badge>
               )}
             </h1>
@@ -182,11 +184,11 @@ export default function Markets() {
               className="flex items-center gap-2 border-white/10 hover:bg-white/5 disabled:opacity-40"
             >
               <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-              {isOffline ? 'Offline' : 'Refresh'}
+              {isOffline ? t('markets.offline') : t('markets.refresh')}
             </Button>
           </div>
           <p className="text-muted-foreground">
-            Browse and trade on {markets.length} prediction markets
+            {t('markets.subtitle', { count: markets.length })}
           </p>
         </div>
 
@@ -196,7 +198,7 @@ export default function Markets() {
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
               <Input
-                placeholder="Search by question or #tag..."
+                placeholder={t('markets.search')}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-10 input-dark border-white/10 focus:border-primary/50"
@@ -232,7 +234,7 @@ export default function Markets() {
             </div>
             <div className="flex items-center gap-2">
               <SortAsc className="w-4 h-4 text-muted-foreground" />
-              <span className="text-sm text-muted-foreground">Sort:</span>
+              <span className="text-sm text-muted-foreground">{t('markets.sort')}</span>
               {(['volume', 'newest', 'ending'] as SortOption[]).map((option) => (
                 <Button
                   key={option}
@@ -241,7 +243,7 @@ export default function Markets() {
                   onClick={() => setSortBy(option)}
                   className={`tab-button capitalize ${sortBy === option ? 'active' : ''}`}
                 >
-                  {option === 'ending' ? 'Ending Soon' : option}
+                  {option === 'ending' ? t('markets.endingSoon') : option}
                 </Button>
               ))}
             </div>
@@ -266,7 +268,7 @@ export default function Markets() {
         {!loading && filteredMarkets.length === 0 && (
           <div className="text-center py-20">
             <p className="text-muted-foreground text-lg">
-              {markets.length === 0 ? 'No markets available' : 'No markets found matching your criteria'}
+              {markets.length === 0 ? t('markets.noMarkets') : t('markets.noResults')}
             </p>
             {markets.length > 0 && (
               <Button 
@@ -278,7 +280,7 @@ export default function Markets() {
                   setSelectedStatus('All');
                 }}
               >
-                Clear filters
+                {t('markets.clearFilters')}
               </Button>
             )}
           </div>


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support to the frontend, enabling the app to be used in English, Spanish, and French. It adds a new i18n context/provider, updates navigation and the market creation page to use translation keys, and provides a language switcher in the navigation bar for both desktop and mobile views.

**Internationalization (i18n) Support:**

- Added a new `i18n` module with an `I18nProvider` and `useI18n` hook, supporting English, Spanish, and French translations for navigation and market creation UI. The provider handles language selection, persists the choice in localStorage, and exposes a translation function (`t`).

**Navigation Bar Updates:**

- Refactored navigation items in `Navbar` to use translation keys instead of hardcoded strings, and integrated the `useI18n` hook for dynamic translation.
- Added a language switcher dropdown to the navigation bar for both desktop and mobile menus, allowing users to change the app language. [[1]](diffhunk://#diff-c22873cfa0903b4833646d2472142ebd6b04da619270415c6381028b9f332a33L51-R72) [[2]](diffhunk://#diff-c22873cfa0903b4833646d2472142ebd6b04da619270415c6381028b9f332a33L127-R153)
- Updated the mobile menu title and navigation item labels to use translated values. [[1]](diffhunk://#diff-c22873cfa0903b4833646d2472142ebd6b04da619270415c6381028b9f332a33L93-R108) [[2]](diffhunk://#diff-c22873cfa0903b4833646d2472142ebd6b04da619270415c6381028b9f332a33L114-R129)

**App Shell Integration:**

- Wrapped the entire app in the `I18nProvider` at the top level to ensure translation context is available throughout the application. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR28) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR65) [[3]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR97)

**Market Creation Page:**

- Updated the Create Market page to use the translation function for all user-facing strings, including headings, labels, placeholders, and helper text. [[1]](diffhunk://#diff-0445f07d38af6d95921f4c35116791ae336f43dc21d276bf68b06761dc921856R17-R22) [[2]](diffhunk://#diff-0445f07d38af6d95921f4c35116791ae336f43dc21d276bf68b06761dc921856L167-R171) [[3]](diffhunk://#diff-0445f07d38af6d95921f4c35116791ae336f43dc21d276bf68b06761dc921856L179-R199)

Closes #77 