### PR TITLE
Fix issue #115: add trade replay protection

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -258,11 +258,14 @@ Authorization: Bearer <token>
   "marketId": "market_123456789",
   "tokenType": "yes",
   "tradeType": "buy",
+  "nonce": "wallet-client-unique-1716880000000",
   "amount": 100,
   "maxSlippage": 0.05,
   "walletAddress": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 }
 ```
+
+`nonce` must be unique per wallet for each submission. Reusing a previous nonce is rejected to prevent replayed trades.
 
 #### Get Trade History
 ```http

--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -102,7 +102,8 @@ class TradeController {
       const trade = new Trade({
         tradeId,
         marketId,
-        userWalletAddress: req.user.walletAddress,
+        userWalletAddress: normalizedWalletAddress,
+        nonce,
         tradeType,
         tokenType,
         amount: effectiveAmount,
@@ -136,7 +137,7 @@ class TradeController {
       tradeBatcher.addTrade({
         tradeId,
         marketId,
-        userWalletAddress: req.user.walletAddress,
+        userWalletAddress: normalizedWalletAddress,
         tradeType,
         tokenType,
         amount: effectiveAmount,
@@ -147,7 +148,8 @@ class TradeController {
       logger.trade('Trade queued for batch execution', {
         tradeId,
         marketId,
-        user: req.user.walletAddress,
+        user: normalizedWalletAddress,
+        nonce,
         tokenType,
         tradeType,
         requestedAmount: amount,
@@ -164,6 +166,7 @@ class TradeController {
           trade: {
             tradeId,
             marketId,
+            nonce,
             tokenType,
             tradeType,
             requestedAmount: amount,

--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -15,7 +15,8 @@ class TradeController {
       tradeType,
       amount,
       maxSlippage = 0.05,
-      walletAddress
+      walletAddress,
+      nonce
     } = req.body;
 
     // Verify user owns the wallet
@@ -34,6 +35,23 @@ class TradeController {
 
     if (market.expiresAt <= new Date()) {
       throw new ValidationError('Market has expired');
+    }
+
+    const normalizedWalletAddress = req.user.walletAddress.toLowerCase();
+    const existingNonceTrade = await Trade.findOne({
+      userWalletAddress: normalizedWalletAddress,
+      nonce
+    }).select('tradeId status timestamp');
+
+    if (existingNonceTrade) {
+      logger.warn('[SECURITY] Suspicious trade replay attempt detected', {
+        marketId,
+        walletAddress: normalizedWalletAddress,
+        nonce,
+        existingTradeId: existingNonceTrade.tradeId,
+        existingTradeStatus: existingNonceTrade.status
+      });
+      throw new ValidationError('Duplicate trade submission detected');
     }
 
     const tradeId = `trade_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -163,6 +163,12 @@ const tradeValidations = {
       .isIn(['buy', 'sell'])
       .withMessage('Trade type must be buy or sell'),
 
+    body('nonce')
+      .isString()
+      .isLength({ min: 8, max: 128 })
+      .withMessage('Nonce must be a string between 8 and 128 characters')
+      .trim(),
+
     commonValidations.amount,
 
     body('maxSlippage')

--- a/backend/src/models/Trade.js
+++ b/backend/src/models/Trade.js
@@ -18,6 +18,10 @@ const tradeSchema = new mongoose.Schema({
     required: true,
     index: true
   },
+  nonce: {
+    type: String,
+    required: true
+  },
   tradeType: {
     type: String,
     enum: ['buy', 'sell'],
@@ -146,6 +150,7 @@ const tradeSchema = new mongoose.Schema({
 // Compound indexes for better query performance
 tradeSchema.index({ marketId: 1, timestamp: -1 });
 tradeSchema.index({ userWalletAddress: 1, timestamp: -1 });
+tradeSchema.index({ userWalletAddress: 1, nonce: 1 }, { unique: true });
 tradeSchema.index({ marketId: 1, tokenType: 1, timestamp: -1 });
 tradeSchema.index({ status: 1, timestamp: -1 });
 tradeSchema.index({ tradeType: 1, tokenType: 1 });


### PR DESCRIPTION
## Summary
- add per-wallet nonce storage and unique index on trades to enforce replay protection at the database layer
- require and validate `nonce` on trade execution requests, then block duplicate submissions before execution
- log suspicious replay attempts and document the nonce requirement in backend API docs

## Verification
- confirmed no linter errors in edited files via IDE diagnostics
- verified recent commit author/committer is `fortezzalaboratory <fortezzalabs@gmail.com>` using `git log --format`
- tests not run (intentionally skipped per instruction)

Closes #115

Made with [Cursor](https://cursor.com)