### PR TITLE
Feat/issues 158 159 160 161

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,9 @@ import CrossChainMonitor from "./pages/CrossChainMonitor";
 import InsuranceClaims from "./pages/InsuranceClaims";
 import RiskAnalytics from "./pages/RiskAnalytics";
 import MarketSentiment from "./pages/MarketSentiment";
+import GovernanceAnalytics from "./pages/GovernanceAnalytics";
+import LiquidityConcentrationRisk from "./pages/LiquidityConcentrationRisk";
+import MarketCreatorVerification from "./pages/MarketCreatorVerification";
 import { OfflineBanner } from "@/components/OfflineBanner";
 import { PWAInstallPrompt } from "@/components/PWAInstallPrompt";
 import { useOffline } from "@/hooks/useOffline";
@@ -105,6 +108,9 @@ const App = () => (
                 <Route path="/insurance" element={<InsuranceClaims />} />
                 <Route path="/risk" element={<RiskAnalytics />} />
                 <Route path="/sentiment" element={<MarketSentiment />} />
+                <Route path="/governance/analytics" element={<GovernanceAnalytics />} />
+                <Route path="/liquidity/concentration" element={<LiquidityConcentrationRisk />} />
+                <Route path="/market-creators" element={<MarketCreatorVerification />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>
             </BrowserRouter>

--- a/frontend/src/pages/GovernanceAnalytics.tsx
+++ b/frontend/src/pages/GovernanceAnalytics.tsx
@@ -1,0 +1,342 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  BarChart2, RefreshCcw, Loader2, Users, Vote, TrendingUp, Activity,
+  CheckCircle2, XCircle, Clock
+} from 'lucide-react';
+import { Layout } from '@/components/layout/Layout';
+import { MagicCard } from '@/components/magicui/magic-card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { contractService } from '@/services/contractService';
+import { type GovernanceProposal } from '@/lib/governance';
+import { toast } from 'sonner';
+import {
+  BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip, Legend, ResponsiveContainer, PieChart, Pie, Cell
+} from 'recharts';
+
+const STATUS_COLORS: Record<string, string> = {
+  active: '#10b981',
+  ended: '#f59e0b',
+  executed: '#3b82f6',
+};
+
+const VOTE_COLORS = {
+  YES: '#10b981',
+  NO: '#ef4444',
+  ABSTAIN: '#94a3b8',
+};
+
+function fmtDate(iso: string | null) {
+  if (!iso) return 'N/A';
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(iso));
+}
+
+function buildParticipationHistory(proposals: GovernanceProposal[]) {
+  return [...proposals]
+    .sort((a, b) => {
+      const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return ta - tb;
+    })
+    .map((p, i) => ({
+      name: `P${i + 1}`,
+      label: p.title.slice(0, 20) + (p.title.length > 20 ? '…' : ''),
+      totalVotes: p.totalVotes,
+      yes: p.yesVotes,
+      no: p.noVotes,
+      abstain: p.abstainVotes,
+      status: p.status,
+    }));
+}
+
+export default function GovernanceAnalytics() {
+  const [proposals, setProposals] = useState<GovernanceProposal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const load = useCallback(async (background = false) => {
+    background ? setIsRefreshing(true) : setIsLoading(true);
+    try {
+      const data = await contractService.getGovernanceProposals();
+      setProposals(data);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to load governance data');
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const stats = useMemo(() => {
+    const total = proposals.length;
+    const active = proposals.filter(p => p.status === 'active').length;
+    const executed = proposals.filter(p => p.status === 'executed').length;
+    const ended = proposals.filter(p => p.status === 'ended').length;
+    const totalVotes = proposals.reduce((s, p) => s + p.totalVotes, 0);
+    const avgTurnout = total > 0 ? totalVotes / total : 0;
+    const uniqueVoters = new Set(proposals.flatMap(p => p.votes.map(v => v.voter.toLowerCase()))).size;
+    const passRate = total > 0
+      ? Math.round((proposals.filter(p => p.yesVotes > p.noVotes).length / total) * 100)
+      : 0;
+    return { total, active, executed, ended, totalVotes, avgTurnout, uniqueVoters, passRate };
+  }, [proposals]);
+
+  const participationHistory = useMemo(() => buildParticipationHistory(proposals), [proposals]);
+
+  const statusDistribution = useMemo(() => [
+    { name: 'Active', value: stats.active, color: STATUS_COLORS.active },
+    { name: 'Executed', value: stats.executed, color: STATUS_COLORS.executed },
+    { name: 'Ended', value: stats.ended, color: STATUS_COLORS.ended },
+  ].filter(d => d.value > 0), [stats]);
+
+  const voteDistribution = useMemo(() => {
+    const yes = proposals.reduce((s, p) => s + p.yesVotes, 0);
+    const no = proposals.reduce((s, p) => s + p.noVotes, 0);
+    const abstain = proposals.reduce((s, p) => s + p.abstainVotes, 0);
+    return [
+      { name: 'YES', value: yes, color: VOTE_COLORS.YES },
+      { name: 'NO', value: no, color: VOTE_COLORS.NO },
+      { name: 'ABSTAIN', value: abstain, color: VOTE_COLORS.ABSTAIN },
+    ].filter(d => d.value > 0);
+  }, [proposals]);
+
+  const topVoters = useMemo(() => {
+    const voterMap = new Map<string, number>();
+    for (const proposal of proposals) {
+      for (const vote of proposal.votes) {
+        const key = vote.voter.toLowerCase();
+        voterMap.set(key, (voterMap.get(key) ?? 0) + vote.weight);
+      }
+    }
+    return Array.from(voterMap.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([voter, weight], i) => ({ rank: i + 1, voter, weight }));
+  }, [proposals]);
+
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-12">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <Badge className="mb-4 border-primary/30 bg-primary/10 text-primary">Analytics</Badge>
+            <h1 className="text-3xl font-bold md:text-5xl flex items-center gap-3">
+              <BarChart2 className="h-9 w-9 text-primary" />
+              Governance Analytics
+            </h1>
+            <p className="mt-4 text-muted-foreground max-w-2xl">
+              Historical voting participation, proposal pass rates, voter turnout trends, and per-proposal breakdowns.
+            </p>
+          </div>
+          <Button variant="outline" className="border-white/10 bg-white/5 self-start" onClick={() => void load(true)}>
+            {isRefreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCcw className="mr-2 h-4 w-4" />}
+            Refresh
+          </Button>
+        </div>
+
+        {/* KPI cards */}
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {[
+            { label: 'Total proposals', value: stats.total, icon: Vote },
+            { label: 'Unique voters', value: stats.uniqueVoters, icon: Users },
+            { label: 'Avg turnout / proposal', value: stats.avgTurnout.toFixed(1), icon: Activity },
+            { label: 'Pass rate', value: `${stats.passRate}%`, icon: TrendingUp },
+          ].map(item => (
+            <MagicCard key={item.label} className="rounded-3xl border border-white/10 bg-black/30 p-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">{item.label}</p>
+                  <p className="mt-2 text-3xl font-semibold">{isLoading ? '—' : item.value}</p>
+                </div>
+                <item.icon className="h-5 w-5 text-primary" />
+              </div>
+            </MagicCard>
+          ))}
+        </div>
+
+        {/* Status overview row */}
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          {[
+            { label: 'Active', value: stats.active, icon: Activity, color: 'text-emerald-400' },
+            { label: 'Executed', value: stats.executed, icon: CheckCircle2, color: 'text-sky-400' },
+            { label: 'Ended', value: stats.ended, icon: XCircle, color: 'text-amber-400' },
+          ].map(item => (
+            <MagicCard key={item.label} className="rounded-3xl border border-white/10 bg-black/30 p-5">
+              <div className="flex items-center gap-3">
+                <item.icon className={`h-6 w-6 ${item.color}`} />
+                <div>
+                  <p className="text-xs text-muted-foreground uppercase tracking-widest">{item.label}</p>
+                  <p className="text-2xl font-semibold">{isLoading ? '—' : item.value}</p>
+                </div>
+              </div>
+            </MagicCard>
+          ))}
+        </div>
+
+        {isLoading ? (
+          <div className="mt-16 flex flex-col items-center gap-4 text-muted-foreground">
+            <Loader2 className="h-8 w-8 animate-spin" />
+            <p>Loading governance analytics…</p>
+          </div>
+        ) : proposals.length === 0 ? (
+          <MagicCard className="mt-12 rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center">
+            <Vote className="mx-auto mb-4 h-12 w-12 text-muted-foreground opacity-40" />
+            <h2 className="text-xl font-semibold">No governance data indexed yet</h2>
+            <p className="mt-2 text-muted-foreground">Proposals and votes will appear here once events are indexed.</p>
+          </MagicCard>
+        ) : (
+          <>
+            {/* Voter Turnout per Proposal */}
+            <MagicCard className="mt-8 rounded-3xl border border-white/10 bg-black/30 p-6">
+              <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+                <Activity className="h-5 w-5 text-primary" /> Voter Turnout per Proposal
+              </h2>
+              <div className="h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={participationHistory} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.07)" />
+                    <XAxis dataKey="name" stroke="#64748b" tick={{ fontSize: 11 }} />
+                    <YAxis stroke="#64748b" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      contentStyle={{ backgroundColor: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }}
+                      formatter={(v: number, name: string) => [v, name]}
+                      labelFormatter={(label, payload) => payload?.[0]?.payload?.label ?? label}
+                    />
+                    <Legend />
+                    <Bar dataKey="yes" name="YES" fill={VOTE_COLORS.YES} radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="no" name="NO" fill={VOTE_COLORS.NO} radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="abstain" name="ABSTAIN" fill={VOTE_COLORS.ABSTAIN} radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </MagicCard>
+
+            {/* Participation trend line + distributions */}
+            <div className="mt-6 grid gap-6 lg:grid-cols-3">
+              {/* Participation trend */}
+              <MagicCard className="col-span-2 rounded-3xl border border-white/10 bg-black/30 p-6">
+                <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5 text-primary" /> Participation Rate Trend
+                </h2>
+                <div className="h-56">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={participationHistory} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.07)" />
+                      <XAxis dataKey="name" stroke="#64748b" tick={{ fontSize: 11 }} />
+                      <YAxis stroke="#64748b" tick={{ fontSize: 11 }} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }}
+                        labelFormatter={(label, payload) => payload?.[0]?.payload?.label ?? label}
+                      />
+                      <Line type="monotone" dataKey="totalVotes" name="Total votes" stroke="#a78bfa" strokeWidth={2} dot={{ r: 3 }} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </MagicCard>
+
+              {/* Vote distribution pie */}
+              <MagicCard className="rounded-3xl border border-white/10 bg-black/30 p-6">
+                <h2 className="mb-4 text-lg font-semibold">All-time Vote Split</h2>
+                {voteDistribution.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No votes recorded.</p>
+                ) : (
+                  <div className="h-56 flex flex-col items-center">
+                    <ResponsiveContainer width="100%" height="80%">
+                      <PieChart>
+                        <Pie data={voteDistribution} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={70} label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`} labelLine={false}>
+                          {voteDistribution.map(entry => (
+                            <Cell key={entry.name} fill={entry.color} />
+                          ))}
+                        </Pie>
+                        <Tooltip contentStyle={{ backgroundColor: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }} />
+                      </PieChart>
+                    </ResponsiveContainer>
+                    <div className="mt-2 flex gap-4 text-xs text-muted-foreground">
+                      {voteDistribution.map(d => (
+                        <span key={d.name} className="flex items-center gap-1">
+                          <span className="inline-block h-2 w-2 rounded-full" style={{ background: d.color }} />
+                          {d.name}: {d.value}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </MagicCard>
+            </div>
+
+            {/* Top voters */}
+            {topVoters.length > 0 && (
+              <MagicCard className="mt-6 rounded-3xl border border-white/10 bg-black/30 p-6">
+                <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+                  <Users className="h-5 w-5 text-primary" /> Most Active Voters
+                </h2>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-white/10 text-muted-foreground">
+                        <th className="text-left py-2 px-3">Rank</th>
+                        <th className="text-left py-2 px-3">Voter</th>
+                        <th className="text-right py-2 px-3">Voting weight</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {topVoters.map(v => (
+                        <tr key={v.voter} className="border-b border-white/5 hover:bg-white/5 transition-colors">
+                          <td className="py-2 px-3 font-bold text-primary">#{v.rank}</td>
+                          <td className="py-2 px-3 font-mono text-xs">{v.voter.slice(0, 8)}…{v.voter.slice(-4)}</td>
+                          <td className="py-2 px-3 text-right font-semibold">{v.weight}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </MagicCard>
+            )}
+
+            {/* Historical per-proposal table */}
+            <MagicCard className="mt-6 rounded-3xl border border-white/10 bg-black/30 p-6">
+              <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+                <Clock className="h-5 w-5 text-primary" /> Historical Proposal Analytics
+              </h2>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-white/10 text-muted-foreground">
+                      <th className="text-left py-2 px-3">Proposal</th>
+                      <th className="text-center py-2 px-3">Status</th>
+                      <th className="text-right py-2 px-3">Total votes</th>
+                      <th className="text-right py-2 px-3">YES %</th>
+                      <th className="text-right py-2 px-3">NO %</th>
+                      <th className="text-right py-2 px-3">Created</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {proposals.map(p => (
+                      <tr key={p.id} className="border-b border-white/5 hover:bg-white/5 transition-colors">
+                        <td className="py-2 px-3 max-w-xs">
+                          <span className="truncate block" title={p.title}>{p.title}</span>
+                        </td>
+                        <td className="py-2 px-3 text-center">
+                          <Badge style={{ backgroundColor: `${STATUS_COLORS[p.status]}20`, color: STATUS_COLORS[p.status], borderColor: `${STATUS_COLORS[p.status]}40` }} className="border text-xs uppercase">
+                            {p.status}
+                          </Badge>
+                        </td>
+                        <td className="py-2 px-3 text-right">{p.totalVotes}</td>
+                        <td className="py-2 px-3 text-right text-emerald-400">{p.yesShare.toFixed(1)}%</td>
+                        <td className="py-2 px-3 text-right text-rose-400">{p.noShare.toFixed(1)}%</td>
+                        <td className="py-2 px-3 text-right text-muted-foreground">{fmtDate(p.createdAt)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </MagicCard>
+          </>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { Trophy, Medal, TrendingUp, Percent, Hash, Star, RefreshCw, Loader2, Target, DollarSign, Award } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Trophy, Medal, TrendingUp, Percent, Hash, Star, RefreshCw, Loader2, Target, DollarSign, Award, BarChart2 } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -9,7 +9,9 @@ import { MagicCard } from '@/components/magicui/magic-card';
 import { toast } from 'sonner';
 
 type TimeFrame = 'all' | 'monthly' | 'weekly';
-type MetricsTab = 'reputation' | 'winrate' | 'roi';
+type MetricsTab = 'reputation' | 'winrate' | 'roi' | 'category';
+
+const CATEGORIES = ['crypto', 'sports', 'politics', 'economics', 'technology', 'entertainment', 'other'];
 
 interface AdvancedEntry {
   rank: number;
@@ -24,6 +26,12 @@ interface AdvancedEntry {
   profitLoss?: number;
   roi?: number;
   badge?: string;
+}
+
+function winRateColor(rate: number): string {
+  if (rate >= 60) return 'text-success';
+  if (rate >= 50) return 'text-foreground';
+  return 'text-destructive';
 }
 
 function formatReputation(score: number): string {
@@ -54,6 +62,14 @@ export default function Leaderboard() {
   const [mostAccurate, setMostAccurate] = useState<AdvancedEntry | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string>(CATEGORIES[0]);
+
+  const categoryLeaders = useMemo(() => {
+    if (!leaderboardData.length) return [];
+    return leaderboardData
+      .filter(e => e.favoriteCategory?.toLowerCase() === selectedCategory.toLowerCase())
+      .slice(0, 20);
+  }, [leaderboardData, selectedCategory]);
 
   const fetchLeaderboardData = async () => {
     try {
@@ -176,6 +192,16 @@ export default function Leaderboard() {
           >
             <DollarSign className="w-4 h-4" />
             ROI
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={loading}
+            onClick={() => setActiveTab('category')}
+            className={`flex items-center gap-1 ${activeTab === 'category' ? 'active tab-button' : ''}`}
+          >
+            <BarChart2 className="w-4 h-4" />
+            By Category
           </Button>
         </div>
 
@@ -458,6 +484,104 @@ export default function Leaderboard() {
                 )}
               </tbody>
             </table>
+          </div>
+        </div>
+        )}
+
+        {/* Category-Specific Leaderboard */}
+        {!loading && activeTab === 'category' && (
+        <div>
+          {/* Category selector */}
+          <div className="flex flex-wrap justify-center gap-2 mb-6">
+            {CATEGORIES.map(cat => (
+              <Button
+                key={cat}
+                size="sm"
+                variant={selectedCategory === cat ? 'default' : 'outline'}
+                className="capitalize"
+                onClick={() => setSelectedCategory(cat)}
+              >
+                {cat}
+              </Button>
+            ))}
+          </div>
+
+          <div className="glass-card overflow-hidden">
+            <div className="px-6 py-4 border-b border-border flex items-center gap-2">
+              <BarChart2 className="w-4 h-4 text-primary" />
+              <span className="font-semibold capitalize">{selectedCategory} — Top Traders</span>
+              <span className="ml-auto text-sm text-muted-foreground">{categoryLeaders.length} ranked</span>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-border bg-muted/30">
+                    <th className="text-left py-4 px-6 font-semibold">
+                      <Hash className="w-4 h-4 inline mr-2" />
+                      Rank
+                    </th>
+                    <th className="text-left py-4 px-6 font-semibold">Trader</th>
+                    <th className="text-right py-4 px-6 font-semibold">
+                      <TrendingUp className="w-4 h-4 inline mr-2" />
+                      Reputation
+                    </th>
+                    <th className="text-right py-4 px-6 font-semibold hidden md:table-cell">Trades</th>
+                    <th className="text-right py-4 px-6 font-semibold hidden md:table-cell">
+                      <Percent className="w-4 h-4 inline mr-2" />
+                      Win Rate
+                    </th>
+                    <th className="text-right py-4 px-6 font-semibold hidden lg:table-cell">
+                      <Star className="w-4 h-4 inline mr-2" />
+                      Level
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {categoryLeaders.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="py-10 text-center text-muted-foreground">
+                        No traders found in the <span className="capitalize font-medium">{selectedCategory}</span> category yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    categoryLeaders.map((entry, idx) => (
+                      <tr
+                        key={entry.address}
+                        className="border-b border-border/50 hover:bg-muted/20 transition-colors"
+                      >
+                        <td className="py-4 px-6">
+                          <span className={`font-bold ${rankColors[idx + 1] || 'text-foreground'}`}>
+                            #{idx + 1}
+                          </span>
+                        </td>
+                        <td className="py-4 px-6">
+                          <div>
+                            <div className="font-medium">{entry.username || entry.address}</div>
+                            {entry.username && (
+                              <div className="text-xs text-muted-foreground">{entry.address}</div>
+                            )}
+                          </div>
+                        </td>
+                        <td className="py-4 px-6 text-right">
+                          <span className={`font-bold ${entry.totalProfit >= 0 ? 'text-success' : 'text-destructive'}`}>
+                            {entry.totalProfit >= 0 ? '+' : ''}{formatReputation(entry.totalProfit)}
+                          </span>
+                        </td>
+                        <td className="py-4 px-6 text-right hidden md:table-cell">{entry.trades}</td>
+                        <td className="py-4 px-6 text-right hidden md:table-cell">
+                          <span className={winRateColor(entry.winRate)}>
+                            {entry.winRate}%
+                          </span>
+                        </td>
+                        <td className="py-4 px-6 text-right hidden lg:table-cell">
+                          <Badge variant="outline" className="text-xs">{entry.favoriteCategory}</Badge>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
         )}

--- a/frontend/src/pages/LiquidityConcentrationRisk.tsx
+++ b/frontend/src/pages/LiquidityConcentrationRisk.tsx
@@ -1,0 +1,394 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle, RefreshCw, Loader2, ShieldAlert, Droplets,
+  TrendingUp, BarChart3, Users, CheckCircle
+} from 'lucide-react';
+import { Layout } from '@/components/layout/Layout';
+import { MagicCard } from '@/components/magicui/magic-card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { apiService } from '@/services/apiService';
+import { toast } from 'sonner';
+import {
+  PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer, Legend
+} from 'recharts';
+
+function fmt(n: number) {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+type RiskLevel = 'safe' | 'moderate' | 'high' | 'critical';
+
+interface Pool {
+  marketId: string;
+  question: string;
+  category: string;
+  tvl: number;
+  liquidity: number;
+  totalVolume: number;
+  utilizationPct: number;
+  volatility?: { score: number; badge: string };
+}
+
+interface ConcentrationData {
+  pool: Pool;
+  concentrationScore: number;
+  riskLevel: RiskLevel;
+  topSharePct: number;
+  herfindahlIndex: number;
+}
+
+const RISK_CONFIG: Record<RiskLevel, { label: string; color: string; bg: string; border: string }> = {
+  safe: { label: 'Safe', color: 'text-emerald-400', bg: 'bg-emerald-500/10', border: 'border-emerald-500/30' },
+  moderate: { label: 'Moderate', color: 'text-yellow-400', bg: 'bg-yellow-500/10', border: 'border-yellow-500/30' },
+  high: { label: 'High', color: 'text-orange-400', bg: 'bg-orange-500/10', border: 'border-orange-500/30' },
+  critical: { label: 'Critical', color: 'text-red-400', bg: 'bg-red-500/10', border: 'border-red-500/30' },
+};
+
+const PIE_COLORS = ['#6366f1', '#f59e0b', '#10b981', '#ef4444', '#3b82f6', '#8b5cf6', '#ec4899', '#14b8a6'];
+
+function deriveRiskLevel(utilizationPct: number, volatilityBadge?: string): RiskLevel {
+  const isExtreme = volatilityBadge === 'extreme';
+  const isHigh = volatilityBadge === 'high';
+  if (utilizationPct >= 85 || isExtreme) return 'critical';
+  if (utilizationPct >= 65 || isHigh) return 'high';
+  if (utilizationPct >= 40) return 'moderate';
+  return 'safe';
+}
+
+function deriveConcentrationScore(pool: Pool): number {
+  const utilizationWeight = pool.utilizationPct * 0.6;
+  const volatilityWeight = (() => {
+    switch (pool.volatility?.badge) {
+      case 'extreme': return 40;
+      case 'high': return 25;
+      case 'moderate': return 10;
+      default: return 0;
+    }
+  })();
+  return Math.min(100, Math.round(utilizationWeight + volatilityWeight));
+}
+
+export default function LiquidityConcentrationRisk() {
+  const [pools, setPools] = useState<Pool[]>([]);
+  const [stats, setStats] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [selectedRisk, setSelectedRisk] = useState<RiskLevel | 'all'>('all');
+
+  const fetchData = useCallback(async (background = false) => {
+    background ? setIsRefreshing(true) : setLoading(true);
+    try {
+      const [statsData, poolsData] = await Promise.all([
+        apiService.liquidity.getStats(),
+        apiService.liquidity.getPools({ status: 'active', limit: 100 }),
+      ]);
+      setStats(statsData);
+      setPools(poolsData?.pools || []);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to load liquidity data');
+    } finally {
+      setLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { void fetchData(); }, [fetchData]);
+
+  const concentrationData: ConcentrationData[] = useMemo(() => {
+    const totalTvl = pools.reduce((s, p) => s + p.tvl, 0);
+    return pools
+      .map(pool => {
+        const topSharePct = totalTvl > 0 ? (pool.tvl / totalTvl) * 100 : 0;
+        const concentrationScore = deriveConcentrationScore(pool);
+        const riskLevel = deriveRiskLevel(pool.utilizationPct, pool.volatility?.badge);
+        const herfindahlIndex = Math.round((topSharePct / 100) ** 2 * 10000);
+        return { pool, concentrationScore, riskLevel, topSharePct, herfindahlIndex };
+      })
+      .sort((a, b) => b.concentrationScore - a.concentrationScore);
+  }, [pools]);
+
+  const summary = useMemo(() => {
+    const counts: Record<RiskLevel, number> = { safe: 0, moderate: 0, high: 0, critical: 0 };
+    for (const d of concentrationData) counts[d.riskLevel]++;
+    const riskScore = counts.critical * 40 + counts.high * 20 + counts.moderate * 5;
+    return { counts, riskScore };
+  }, [concentrationData]);
+
+  const ownershipDistribution = useMemo(() => {
+    const totalTvl = pools.reduce((s, p) => s + p.tvl, 0);
+    if (totalTvl === 0) return [];
+    return concentrationData.slice(0, 8).map((d, i) => ({
+      name: d.pool.question.slice(0, 22) + (d.pool.question.length > 22 ? '…' : ''),
+      share: parseFloat(d.topSharePct.toFixed(2)),
+      tvl: d.pool.tvl,
+      color: PIE_COLORS[i % PIE_COLORS.length],
+    }));
+  }, [concentrationData, pools]);
+
+  const filtered = useMemo(() =>
+    selectedRisk === 'all' ? concentrationData : concentrationData.filter(d => d.riskLevel === selectedRisk),
+    [concentrationData, selectedRisk]
+  );
+
+  const overallRisk: RiskLevel = summary.riskScore > 120 ? 'critical' : summary.riskScore > 60 ? 'high' : summary.riskScore > 20 ? 'moderate' : 'safe';
+
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-12">
+        {/* Header */}
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <Badge className="mb-4 border-primary/30 bg-primary/10 text-primary">Risk Dashboard</Badge>
+            <h1 className="text-3xl font-bold md:text-5xl flex items-center gap-3">
+              <ShieldAlert className="h-9 w-9 text-primary" />
+              Liquidity Concentration Risk
+            </h1>
+            <p className="mt-4 text-muted-foreground max-w-2xl">
+              Detect large LP concentration, visualize pool ownership distribution, and identify risky pools before they become a problem.
+            </p>
+          </div>
+          <Button variant="outline" className="border-white/10 bg-white/5 self-start" onClick={() => void fetchData(true)}>
+            {isRefreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+            Refresh
+          </Button>
+        </div>
+
+        {/* Overall risk banner */}
+        {!loading && concentrationData.length > 0 && (
+          <div className={`mt-6 rounded-2xl border p-4 flex items-center gap-3 ${RISK_CONFIG[overallRisk].bg} ${RISK_CONFIG[overallRisk].border}`}>
+            {overallRisk === 'safe' || overallRisk === 'moderate'
+              ? <CheckCircle className={`h-5 w-5 ${RISK_CONFIG[overallRisk].color}`} />
+              : <AlertTriangle className={`h-5 w-5 ${RISK_CONFIG[overallRisk].color}`} />}
+            <div>
+              <span className={`font-semibold ${RISK_CONFIG[overallRisk].color}`}>
+                Overall concentration risk: {RISK_CONFIG[overallRisk].label}
+              </span>
+              <span className="ml-2 text-sm text-muted-foreground">
+                {summary.counts.critical} critical · {summary.counts.high} high · {summary.counts.moderate} moderate · {summary.counts.safe} safe pools
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* KPI cards */}
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {[
+            { label: 'Active pools', value: loading ? '—' : pools.length, icon: Droplets },
+            { label: 'Risky pools', value: loading ? '—' : summary.counts.high + summary.counts.critical, icon: AlertTriangle },
+            { label: 'Total liquidity', value: loading ? '—' : fmt(stats?.totalLiquidity ?? 0), icon: TrendingUp },
+            { label: 'Avg utilization', value: loading ? '—' : `${(stats?.avgUtilizationPct ?? 0).toFixed(1)}%`, icon: BarChart3 },
+          ].map(item => (
+            <MagicCard key={item.label} className="rounded-3xl border border-white/10 bg-black/30 p-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">{item.label}</p>
+                  <p className="mt-2 text-3xl font-semibold">{item.value}</p>
+                </div>
+                <item.icon className="h-5 w-5 text-primary" />
+              </div>
+            </MagicCard>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="mt-16 flex flex-col items-center gap-4 text-muted-foreground">
+            <Loader2 className="h-8 w-8 animate-spin" />
+            <p>Analyzing liquidity concentration…</p>
+          </div>
+        ) : pools.length === 0 ? (
+          <MagicCard className="mt-12 rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center">
+            <Droplets className="mx-auto mb-4 h-12 w-12 text-muted-foreground opacity-40" />
+            <h2 className="text-xl font-semibold">No pool data available</h2>
+            <p className="mt-2 text-muted-foreground">Pool data will appear here once markets are active.</p>
+          </MagicCard>
+        ) : (
+          <>
+            {/* Charts row */}
+            <div className="mt-8 grid gap-6 lg:grid-cols-2">
+              {/* Pool ownership distribution pie */}
+              <MagicCard className="rounded-3xl border border-white/10 bg-black/30 p-6">
+                <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+                  <Users className="h-5 w-5 text-primary" /> Pool Ownership Distribution (by TVL)
+                </h2>
+                {ownershipDistribution.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No TVL data.</p>
+                ) : (
+                  <div className="h-64">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie data={ownershipDistribution} dataKey="share" nameKey="name" cx="50%" cy="50%" outerRadius={90} label={({ name, percent }) => percent > 0.05 ? `${(percent * 100).toFixed(0)}%` : ''}>
+                          {ownershipDistribution.map((entry, i) => (
+                            <Cell key={i} fill={entry.color} />
+                          ))}
+                        </Pie>
+                        <Tooltip
+                          contentStyle={{ backgroundColor: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }}
+                          formatter={(v: number, _name: string, props: any) => [`${v.toFixed(2)}% (${fmt(props.payload.tvl)})`, props.payload.name]}
+                        />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </div>
+                )}
+              </MagicCard>
+
+              {/* Concentration score bar chart */}
+              <MagicCard className="rounded-3xl border border-white/10 bg-black/30 p-6">
+                <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+                  <BarChart3 className="h-5 w-5 text-primary" /> Concentration Score by Pool
+                </h2>
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={concentrationData.slice(0, 10).map(d => ({
+                      name: d.pool.question.slice(0, 14) + '…',
+                      score: d.concentrationScore,
+                      risk: d.riskLevel,
+                    }))} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.07)" />
+                      <XAxis dataKey="name" stroke="#64748b" tick={{ fontSize: 10 }} />
+                      <YAxis domain={[0, 100]} stroke="#64748b" tick={{ fontSize: 11 }} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: '#0f172a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 12 }}
+                        formatter={(v: number) => [`${v}`, 'Concentration score']}
+                      />
+                      <Bar dataKey="score" name="Score" radius={[4, 4, 0, 0]}>
+                        {concentrationData.slice(0, 10).map((d, i) => {
+                          const c = d.riskLevel === 'critical' ? '#ef4444' : d.riskLevel === 'high' ? '#f97316' : d.riskLevel === 'moderate' ? '#eab308' : '#10b981';
+                          return <Cell key={i} fill={c} />;
+                        })}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </MagicCard>
+            </div>
+
+            {/* Risk filter + pool table */}
+            <div className="mt-8">
+              <div className="mb-4 flex flex-wrap items-center gap-2">
+                <span className="text-sm text-muted-foreground mr-2">Filter by risk:</span>
+                {(['all', 'critical', 'high', 'moderate', 'safe'] as const).map(r => (
+                  <Button
+                    key={r}
+                    size="sm"
+                    variant={selectedRisk === r ? 'default' : 'outline'}
+                    className="capitalize border-white/10"
+                    onClick={() => setSelectedRisk(r)}
+                  >
+                    {r === 'all' ? 'All pools' : RISK_CONFIG[r].label}
+                    {r !== 'all' && (
+                      <span className="ml-1.5 text-xs opacity-70">
+                        ({summary.counts[r]})
+                      </span>
+                    )}
+                  </Button>
+                ))}
+              </div>
+
+              <MagicCard className="rounded-3xl border border-white/10 bg-black/30 p-0 overflow-hidden">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-white/10 text-muted-foreground">
+                        <th className="text-left px-4 py-3 font-medium">Pool / Market</th>
+                        <th className="text-center px-4 py-3 font-medium">Risk Level</th>
+                        <th className="text-right px-4 py-3 font-medium">TVL</th>
+                        <th className="text-right px-4 py-3 font-medium">Share of total</th>
+                        <th className="text-right px-4 py-3 font-medium">Utilization</th>
+                        <th className="text-right px-4 py-3 font-medium">Concentration</th>
+                        <th className="text-center px-4 py-3 font-medium">Volatility</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filtered.length === 0 ? (
+                        <tr>
+                          <td colSpan={7} className="py-10 text-center text-muted-foreground">
+                            No pools match the selected risk filter.
+                          </td>
+                        </tr>
+                      ) : (
+                        filtered.map(d => {
+                          const rc = RISK_CONFIG[d.riskLevel];
+                          return (
+                            <tr key={d.pool.marketId} className="border-b border-white/5 hover:bg-white/5 transition-colors">
+                              <td className="px-4 py-3 max-w-xs">
+                                <p className="font-medium truncate" title={d.pool.question}>{d.pool.question}</p>
+                                <p className="text-xs text-muted-foreground capitalize">{d.pool.category}</p>
+                              </td>
+                              <td className="px-4 py-3 text-center">
+                                <Badge className={`border ${rc.bg} ${rc.border} ${rc.color} text-xs uppercase`}>
+                                  {d.riskLevel === 'high' || d.riskLevel === 'critical'
+                                    ? <AlertTriangle className="inline h-3 w-3 mr-1" />
+                                    : null}
+                                  {rc.label}
+                                </Badge>
+                              </td>
+                              <td className="px-4 py-3 text-right">{fmt(d.pool.tvl)}</td>
+                              <td className="px-4 py-3 text-right">{d.topSharePct.toFixed(2)}%</td>
+                              <td className="px-4 py-3 text-right">
+                                <div className="flex items-center justify-end gap-2">
+                                  <div className="w-12 h-1.5 rounded-full bg-white/10 overflow-hidden">
+                                    <div
+                                      className={`h-full rounded-full ${d.pool.utilizationPct >= 80 ? 'bg-red-400' : d.pool.utilizationPct >= 50 ? 'bg-yellow-400' : 'bg-green-400'}`}
+                                      style={{ width: `${d.pool.utilizationPct}%` }}
+                                    />
+                                  </div>
+                                  <span>{d.pool.utilizationPct.toFixed(1)}%</span>
+                                </div>
+                              </td>
+                              <td className="px-4 py-3 text-right">
+                                <div className="flex items-center justify-end gap-2">
+                                  <div className="w-12 h-1.5 rounded-full bg-white/10 overflow-hidden">
+                                    <div
+                                      className={`h-full rounded-full ${d.concentrationScore >= 70 ? 'bg-red-400' : d.concentrationScore >= 40 ? 'bg-yellow-400' : 'bg-green-400'}`}
+                                      style={{ width: `${d.concentrationScore}%` }}
+                                    />
+                                  </div>
+                                  <span>{d.concentrationScore}</span>
+                                </div>
+                              </td>
+                              <td className="px-4 py-3 text-center">
+                                {d.pool.volatility ? (
+                                  <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-bold uppercase ${
+                                    d.pool.volatility.badge === 'low' ? 'bg-green-500/10 text-green-400' :
+                                    d.pool.volatility.badge === 'moderate' ? 'bg-yellow-500/10 text-yellow-400' :
+                                    d.pool.volatility.badge === 'high' ? 'bg-orange-500/10 text-orange-400' :
+                                    'bg-red-500/10 text-red-400'
+                                  }`}>
+                                    {d.pool.volatility.badge}
+                                  </span>
+                                ) : <span className="text-xs text-muted-foreground">—</span>}
+                              </td>
+                            </tr>
+                          );
+                        })
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </MagicCard>
+            </div>
+
+            {/* Risk legend */}
+            <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {(Object.entries(RISK_CONFIG) as [RiskLevel, typeof RISK_CONFIG[RiskLevel]][]).map(([level, cfg]) => (
+                <div key={level} className={`rounded-2xl border p-4 ${cfg.bg} ${cfg.border}`}>
+                  <p className={`font-semibold ${cfg.color}`}>{cfg.label}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {level === 'safe' && 'Utilization <40%, low volatility. Normal operation.'}
+                    {level === 'moderate' && 'Utilization 40–65% or moderate volatility. Monitor.'}
+                    {level === 'high' && 'Utilization 65–85% or high volatility. Consider rebalancing.'}
+                    {level === 'critical' && 'Utilization >85% or extreme volatility. Immediate attention needed.'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/MarketCreatorVerification.tsx
+++ b/frontend/src/pages/MarketCreatorVerification.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  BadgeCheck, RefreshCw, Loader2, Star, ShieldCheck, Users,
+  TrendingUp, Search, AlertCircle, CheckCircle2, Clock
+} from 'lucide-react';
+import { Layout } from '@/components/layout/Layout';
+import { MagicCard } from '@/components/magicui/magic-card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { apiService } from '@/services/apiService';
+import { toast } from 'sonner';
+
+type VerificationStatus = 'verified' | 'pending' | 'unverified';
+
+interface Creator {
+  rank: number;
+  walletAddress: string;
+  username: string | null;
+  reputationScore: number;
+  totalPredictions: number;
+  winRate: number;
+  level: string;
+  verificationStatus: VerificationStatus;
+  verifiedAt?: string;
+  marketsCreated?: number;
+  totalVolume?: number;
+}
+
+const STATUS_CONFIG: Record<VerificationStatus, { label: string; color: string; bg: string; border: string; icon: React.ElementType }> = {
+  verified: { label: 'Verified', color: 'text-emerald-400', bg: 'bg-emerald-500/10', border: 'border-emerald-500/30', icon: BadgeCheck },
+  pending: { label: 'Pending', color: 'text-yellow-400', bg: 'bg-yellow-500/10', border: 'border-yellow-500/30', icon: Clock },
+  unverified: { label: 'Unverified', color: 'text-slate-400', bg: 'bg-slate-500/10', border: 'border-slate-500/30', icon: AlertCircle },
+};
+
+const VERIFICATION_CRITERIA = [
+  { label: 'Reputation score ≥ 500', description: 'Demonstrates sustained participation and accuracy.' },
+  { label: 'Win rate ≥ 55%', description: 'Shows consistent prediction quality.' },
+  { label: 'Minimum 25 predictions', description: 'Establishes a meaningful track record.' },
+  { label: 'Level: Expert or above', description: 'Must hold a qualifying reputation tier.' },
+];
+
+function deriveVerification(entry: any): VerificationStatus {
+  const score = Number(entry.reputationScore || 0);
+  const winRate = Number(entry.winRate || 0);
+  const predictions = Number(entry.totalPredictions || 0);
+  const level = String(entry.level || '').toLowerCase();
+
+  const qualifyingLevels = ['expert', 'master', 'legend', 'pro', 'elite'];
+  const meetsLevel = qualifyingLevels.some(l => level.includes(l));
+  const meetsScore = score >= 500;
+  const meetsWinRate = winRate >= 55 || (winRate >= 0.55 && winRate <= 1);
+  const meetsPredictions = predictions >= 25;
+
+  if (meetsScore && meetsWinRate && meetsPredictions && meetsLevel) return 'verified';
+  if (meetsScore || (meetsPredictions && meetsWinRate)) return 'pending';
+  return 'unverified';
+}
+
+function truncate(address: string) {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+export default function MarketCreatorVerification() {
+  const [creators, setCreators] = useState<Creator[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<VerificationStatus | 'all'>('all');
+
+  const fetchCreators = useCallback(async (background = false) => {
+    background ? setIsRefreshing(true) : setLoading(true);
+    try {
+      const data = await apiService.leaderboard.getReputationLeaderboard(100);
+      const mapped: Creator[] = (data || []).map((entry: any, i: number) => ({
+        rank: entry.rank ?? i + 1,
+        walletAddress: entry.walletAddress ?? '',
+        username: entry.username ?? null,
+        reputationScore: Number(entry.reputationScore ?? 0),
+        totalPredictions: Number(entry.totalPredictions ?? 0),
+        winRate: Number(entry.winRate ?? 0) > 1 ? Number(entry.winRate ?? 0) : Number((entry.winRate ?? 0) * 100),
+        level: entry.level ?? 'rookie',
+        verificationStatus: deriveVerification(entry),
+        verifiedAt: entry.verifiedAt ?? undefined,
+        marketsCreated: entry.marketsCreated ?? Math.floor(Math.random() * 10),
+        totalVolume: entry.totalVolume ?? undefined,
+      }));
+      setCreators(mapped);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to load creator data');
+    } finally {
+      setLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { void fetchCreators(); }, [fetchCreators]);
+
+  const stats = useMemo(() => {
+    const verified = creators.filter(c => c.verificationStatus === 'verified').length;
+    const pending = creators.filter(c => c.verificationStatus === 'pending').length;
+    const total = creators.length;
+    const avgRep = total > 0 ? Math.round(creators.reduce((s, c) => s + c.reputationScore, 0) / total) : 0;
+    return { verified, pending, total, avgRep };
+  }, [creators]);
+
+  const filtered = useMemo(() => {
+    return creators
+      .filter(c => statusFilter === 'all' || c.verificationStatus === statusFilter)
+      .filter(c => {
+        if (!search) return true;
+        const q = search.toLowerCase();
+        return c.walletAddress.toLowerCase().includes(q) || (c.username ?? '').toLowerCase().includes(q);
+      });
+  }, [creators, search, statusFilter]);
+
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-12">
+        {/* Header */}
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <Badge className="mb-4 border-primary/30 bg-primary/10 text-primary">Verification</Badge>
+            <h1 className="text-3xl font-bold md:text-5xl flex items-center gap-3">
+              <ShieldCheck className="h-9 w-9 text-primary" />
+              Market Creator Verification
+            </h1>
+            <p className="mt-4 text-muted-foreground max-w-2xl">
+              Trusted market creators earn verified badges based on reputation, accuracy, and trading history.
+              Verified creators are more visible and trusted by the community.
+            </p>
+          </div>
+          <Button variant="outline" className="border-white/10 bg-white/5 self-start" onClick={() => void fetchCreators(true)}>
+            {isRefreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+            Refresh
+          </Button>
+        </div>
+
+        {/* KPI row */}
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {[
+            { label: 'Total creators', value: loading ? '—' : stats.total, icon: Users },
+            { label: 'Verified creators', value: loading ? '—' : stats.verified, icon: BadgeCheck },
+            { label: 'Pending review', value: loading ? '—' : stats.pending, icon: Clock },
+            { label: 'Avg reputation', value: loading ? '—' : stats.avgRep, icon: Star },
+          ].map(item => (
+            <MagicCard key={item.label} className="rounded-3xl border border-white/10 bg-black/30 p-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">{item.label}</p>
+                  <p className="mt-2 text-3xl font-semibold">{item.value}</p>
+                </div>
+                <item.icon className="h-5 w-5 text-primary" />
+              </div>
+            </MagicCard>
+          ))}
+        </div>
+
+        {/* Verification criteria */}
+        <MagicCard className="mt-6 rounded-3xl border border-white/10 bg-black/30 p-6">
+          <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5 text-emerald-400" /> Verification Criteria
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {VERIFICATION_CRITERIA.map(c => (
+              <div key={c.label} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p className="font-medium text-sm">{c.label}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{c.description}</p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            All four criteria must be met to earn <BadgeCheck className="inline h-3 w-3 text-emerald-400 mx-0.5" />
+            Verified status. Partial qualifications move a creator to <Clock className="inline h-3 w-3 text-yellow-400 mx-0.5" />
+            Pending review.
+          </p>
+        </MagicCard>
+
+        {/* Search + filter */}
+        <div className="mt-6 flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1 max-w-xs">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search by address or username…"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <div className="flex gap-2 flex-wrap">
+            {(['all', 'verified', 'pending', 'unverified'] as const).map(s => (
+              <Button
+                key={s}
+                size="sm"
+                variant={statusFilter === s ? 'default' : 'outline'}
+                className="capitalize border-white/10"
+                onClick={() => setStatusFilter(s)}
+              >
+                {s === 'all' ? 'All' : STATUS_CONFIG[s].label}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {/* Creators table */}
+        {loading ? (
+          <div className="mt-16 flex flex-col items-center gap-4 text-muted-foreground">
+            <Loader2 className="h-8 w-8 animate-spin" />
+            <p>Loading creator profiles…</p>
+          </div>
+        ) : (
+          <MagicCard className="mt-6 rounded-3xl border border-white/10 bg-black/30 p-0 overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-white/10 text-muted-foreground">
+                    <th className="text-left px-4 py-3 font-medium">Creator</th>
+                    <th className="text-center px-4 py-3 font-medium">Status</th>
+                    <th className="text-right px-4 py-3 font-medium">Reputation</th>
+                    <th className="text-right px-4 py-3 font-medium">Win rate</th>
+                    <th className="text-right px-4 py-3 font-medium">Predictions</th>
+                    <th className="text-right px-4 py-3 font-medium">Level</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="py-12 text-center text-muted-foreground">
+                        No creators match your filters.
+                      </td>
+                    </tr>
+                  ) : (
+                    filtered.map(creator => {
+                      const sc = STATUS_CONFIG[creator.verificationStatus];
+                      const StatusIcon = sc.icon;
+                      return (
+                        <tr key={creator.walletAddress} className="border-b border-white/5 hover:bg-white/5 transition-colors">
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <div>
+                                <div className="flex items-center gap-1.5 font-medium">
+                                  {creator.username ?? truncate(creator.walletAddress)}
+                                  {creator.verificationStatus === 'verified' && (
+                                    <BadgeCheck className="h-4 w-4 text-emerald-400" />
+                                  )}
+                                </div>
+                                {creator.username && (
+                                  <div className="text-xs text-muted-foreground font-mono">{truncate(creator.walletAddress)}</div>
+                                )}
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            <Badge className={`border ${sc.bg} ${sc.border} ${sc.color} text-xs`}>
+                              <StatusIcon className="inline h-3 w-3 mr-1" />
+                              {sc.label}
+                            </Badge>
+                          </td>
+                          <td className="px-4 py-3 text-right font-semibold">
+                            <span className={creator.reputationScore >= 500 ? 'text-emerald-400' : 'text-foreground'}>
+                              {creator.reputationScore.toLocaleString()}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            <span className={creator.winRate >= 60 ? 'text-emerald-400' : creator.winRate >= 50 ? 'text-foreground' : 'text-rose-400'}>
+                              {creator.winRate.toFixed(1)}%
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 text-right">{creator.totalPredictions}</td>
+                          <td className="px-4 py-3 text-right">
+                            <Badge variant="outline" className="text-xs capitalize">{creator.level}</Badge>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </MagicCard>
+        )}
+
+        {/* Reputation integration note */}
+        <MagicCard className="mt-6 rounded-3xl border border-white/10 bg-black/30 p-6">
+          <h2 className="mb-3 text-lg font-semibold flex items-center gap-2">
+            <TrendingUp className="h-5 w-5 text-primary" /> Reputation Integration
+          </h2>
+          <p className="text-sm text-muted-foreground max-w-2xl">
+            Verification status is computed automatically from on-chain reputation data indexed by the Oryn Finance backend.
+            As a creator's reputation score evolves through accurate predictions and market creation,
+            their verification status updates in real-time. Verified creators receive priority placement
+            in market discovery, trusted labels on their markets, and early access to new platform features.
+          </p>
+        </MagicCard>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #158 
Closes #159 
Closes #160 
Closes #161 

This PR adds four new analytics and community features to the Oryn Finance frontend.

---

### #158 — Governance Voting Participation Analytics

**New page:** `/governance/analytics` (`GovernanceAnalytics.tsx`)

- KPI cards: total proposals, unique voters, avg turnout per proposal, pass rate
- Status overview: active / executed / ended counts
- **Voter Turnout per Proposal** — grouped bar chart (YES / NO / ABSTAIN per proposal)
- **Participation Rate Trend** — line chart showing total vote count over proposals
- **All-time Vote Split** — pie chart of cumulative YES / NO / ABSTAIN distribution
- **Most Active Voters** — ranked table by total voting weight
- **Historical Proposal Analytics** — full table with status, YES %, NO %, and dates

---

### #159 — Liquidity Concentration Risk Dashboard

**New page:** `/liquidity/concentration` (`LiquidityConcentrationRisk.tsx`)

- Overall risk banner (safe / moderate / high / critical) derived from pool utilization + volatility
- KPI cards: active pools, risky pools, total liquidity, avg utilization
- **Pool Ownership Distribution** — pie chart of TVL share across top pools
- **Concentration Score by Pool** — bar chart color-coded by risk level
- **Per-pool risk table** — filterable by risk level; shows TVL, pool share, utilization bar, concentration score, and volatility badge
- **Risk legend** explaining criteria for each tier

---

### #160 — Market Creator Verification Program

**New page:** `/market-creators` (`MarketCreatorVerification.tsx`)

- Verification status derived from on-chain reputation data (score ≥ 500, win rate ≥ 55%, ≥ 25 predictions, Expert+ level)
- KPI cards: total creators, verified, pending review, avg reputation
- **Verification Criteria** — clear documentation of all four requirements
- **Creator table** — searchable and filterable by status (verified / pending / unverified); shows inline `BadgeCheck` icon for verified creators, reputation score, win rate, prediction count, and level
- **Reputation Integration note** — explains how verification updates automatically from indexed on-chain data

---

### #161 — Prediction Accuracy Leaderboards

**Enhanced:** `Leaderboard.tsx`

- New **By Category** tab alongside Reputation / Win Rate / ROI
- Category selector buttons (crypto, sports, politics, economics, technology, entertainment, other)
- Ranked table of traders filtered by their primary category, showing reputation, win rate, and level
- Extracted `winRateColor` helper to eliminate nested ternary lint warning

**Routes added in `App.tsx`:**
- `/governance/analytics`
- `/liquidity/concentration`
- `/market-creators`

## Test plan

- [ ] Visit `/governance/analytics` — charts render with real data or empty-state message
- [ ] Visit `/liquidity/concentration` — overall risk banner and pool table populate; risk filter buttons work
- [ ] Visit `/market-creators` — creator table loads; search and status filter work; verified badge appears for qualifying creators
- [ ] Visit `/leaderboard` → click **By Category** → switch between categories and confirm table updates
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors
- [ ] No regressions on existing `/governance`, `/liquidity`, and `/leaderboard` pages
