### PR TITLE
Feat/coverage reporting 178

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "20"
+
+jobs:
+  frontend:
+    name: Frontend (Lint, Build, Test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  backend:
+    name: Backend (Lint, Test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+  contracts:
+    name: Smart Contracts (Build, Test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./contracts
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./contracts
+
+      - name: Build
+        run: cargo build --workspace
+
+      - name: Test
+        run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,16 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm test
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          if-no-files-found: warn
+          retention-days: 30
 
   backend:
     name: Backend (Lint, Test)
@@ -62,8 +70,16 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm test
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage/
+          if-no-files-found: warn
+          retention-days: 30
 
   contracts:
     name: Smart Contracts (Build, Test)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ https://youtu.be/1qZALlksIHs?si=f0HuHzg4F_bxwPpQ
 ![Oryn Finance Banner](https://img.shields.io/badge/Oryn%20Finance-Prediction%20Markets-blue?style=for-the-badge)
 [![Stellar](https://img.shields.io/badge/Built%20on-Stellar-black?style=for-the-badge&logo=stellar)](https://stellar.org)
 [![Soroban](https://img.shields.io/badge/Smart%20Contracts-Soroban-yellow?style=for-the-badge)](https://soroban.stellar.org)
+[![CI](https://img.shields.io/github/actions/workflow/status/anomalyco/Oryn-Finance/ci.yml?branch=main&label=CI&logo=github&style=for-the-badge)](https://github.com/anomalyco/Oryn-Finance/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-reported-brightgreen?style=for-the-badge)](https://github.com/anomalyco/Oryn-Finance/actions/workflows/ci.yml)
 
 **Next-Generation Decentralized Prediction Markets on Stellar Blockchain**
 
@@ -298,6 +300,7 @@ graph TB
 {
   "containerization": "Docker",
   "ci_cd": "GitHub Actions",
+  "coverage": "Jest + Vitest Coverage Reports",
   "monitoring": "Winston Logging",
   "documentation": "Swagger/OpenAPI 3.0",
   "security": "Helmet.js + CORS + Rate Limiting"

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "node": true,
+    "commonjs": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": "latest"
+  },
+  "rules": {
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "no-console": "off",
+    "no-undef": "error"
+  },
+  "ignorePatterns": ["node_modules/", "coverage/", "logs/"]
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "prod": "NODE_ENV=production node server.js",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
     "seed": "node src/utils/seedDatabase.js",
     "build": "echo 'No build step required for Node.js'",
     "lint": "eslint .",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -98,6 +99,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^7.3.1",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4"
   }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,20 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "html"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.spec.{ts,tsx}",
+        "src/test/**",
+        "src/**/index.ts",
+        "src/vite-env.d.ts",
+        "src/main.tsx",
+      ],
+    },
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },


### PR DESCRIPTION
Closes #178

### What
Integrated automated coverage reporting into the CI pipeline for both frontend and backend.

### Changes
- **Backend**: `npm run test:coverage` â Jest already had coverage config, added script + CI integration
- **Frontend**: Added `@vitest/coverage-v8` provider, configured in `vitest.config.ts` with lcov/html/text reporters
- **CI Workflow**: Both jobs now run `test:coverage` and upload reports as GitHub Actions artifacts (30-day retention)
- **README**: Added CI status badge, coverage badge, and updated tech stack

### How to access coverage
1. Go to Actions â CI/CD Pipeline workflow run
2. Scroll to Artifacts section
3. Download `frontend-coverage` or `backend-coverage`
4. Open `index.html` in a browser for full interactive report