### PR TITLE
add multi-provider wallet connectivity

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@albedo-link/intent": "^0.13.0",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/frontend/src/components/WalletSelectionModal.tsx
+++ b/frontend/src/components/WalletSelectionModal.tsx
@@ -32,7 +32,14 @@ const WALLET_INSTALL_URLS: Record<string, string> = {
 };
 
 export function WalletSelectionModal({ open, onOpenChange }: WalletSelectionModalProps) {
-  const { connect, isConnecting, network, switchNetwork } = useWallet();
+  const {
+    connect,
+    switchWallet,
+    connectedWallet,
+    isConnecting,
+    network,
+    switchNetwork,
+  } = useWallet();
   const [availableWallets, setAvailableWallets] = useState<WalletInfo[]>([]);
   const [selectedWallet, setSelectedWallet] = useState<WalletType | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -63,7 +70,11 @@ export function WalletSelectionModal({ open, onOpenChange }: WalletSelectionModa
     setError(null);
 
     try {
-      await connect(walletType);
+      if (connectedWallet && connectedWallet !== walletType) {
+        await switchWallet(walletType);
+      } else {
+        await connect(walletType);
+      }
       onOpenChange(false);
       setSelectedWallet(null);
     } catch (error) {

--- a/frontend/src/components/WalletSelector.tsx
+++ b/frontend/src/components/WalletSelector.tsx
@@ -87,6 +87,14 @@ export function WalletSelector() {
                                 </Link>
                             </DropdownMenuItem>
                             <DropdownMenuSeparator className="bg-white/10" />
+                            <DropdownMenuItem
+                                onClick={() => setWalletModalOpen(true)}
+                                className="focus:bg-white/10 focus:text-white cursor-pointer"
+                            >
+                                <Wallet className="w-4 h-4 mr-2" />
+                                Switch wallet
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator className="bg-white/10" />
                             <DropdownMenuItem onClick={disconnect} className="text-red-400 focus:text-red-300 focus:bg-white/10 cursor-pointer">
                                 Disconnect
                             </DropdownMenuItem>

--- a/frontend/src/contexts/WalletContext.tsx
+++ b/frontend/src/contexts/WalletContext.tsx
@@ -1,20 +1,34 @@
-import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
-import { WalletType, FreighterModule, RabetModule } from '@/types/wallet';
-import { connectRabet, signWithRabet, setupRabetEventListeners, disconnectRabet, isRabetAvailable } from '@/wallet/connectRabet';
+import React, {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  WalletNetwork,
+  WalletSession,
+  WalletType,
+} from '@/types/wallet';
+import {
+  getWalletAdapter,
+  NETWORK_PASSPHRASES,
+  walletAdapters,
+} from '@/wallet/providers';
+import {
+  clearWalletSession,
+  loadWalletNetwork,
+  loadWalletSession,
+  saveWalletSession,
+  WALLET_NETWORK_KEY,
+} from '@/wallet/session';
 
-// Stellar network constants
-const STELLAR_NETWORKS = {
-  PUBLIC: 'Public Global Stellar Network ; September 2015',
-  TESTNET: 'Test SDF Network ; September 2015'
+const HORIZON_URLS: Record<WalletNetwork, string> = {
+  mainnet: 'https://horizon.stellar.org',
+  testnet: 'https://horizon-testnet.stellar.org',
 };
-
-// Freighter wallet types
-interface FreighterModule {
-  isConnected(): Promise<boolean>;
-  getPublicKey(): Promise<string>;
-  signTransaction(xdr: string, opts?: { networkPassphrase?: string }): Promise<string>;
-  getNetworkDetails(): Promise<{ networkPassphrase: string; networkUrl: string }>;
-}
 
 interface WalletState {
   isConnected: boolean;
@@ -26,417 +40,289 @@ interface WalletState {
   isRabetInstalled: boolean;
   connectedWallet: WalletType | null;
   networkPassphrase: string | null;
-  network: 'mainnet' | 'testnet';
+  network: WalletNetwork;
+  error: string | null;
 }
 
 interface WalletContextType extends WalletState {
-  publicKey: string | null; // Add publicKey alias for address
+  publicKey: string | null;
   connect: (walletType?: WalletType) => Promise<void>;
-  disconnect: () => void;
+  switchWallet: (walletType: WalletType) => Promise<void>;
+  disconnect: () => Promise<void>;
   signTransaction: (xdr: string) => Promise<string>;
   refreshBalances: () => Promise<void>;
-  switchNetwork: (network: 'mainnet' | 'testnet') => void;
+  switchNetwork: (network: WalletNetwork) => void;
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
-// Stellar network configuration
-const STELLAR_MAINNET_PASSPHRASE = STELLAR_NETWORKS.PUBLIC;
-const STELLAR_TESTNET_PASSPHRASE = STELLAR_NETWORKS.TESTNET;
-const HORIZON_MAINNET_URL = 'https://horizon.stellar.org';
-const HORIZON_TESTNET_URL = 'https://horizon-testnet.stellar.org';
+const disconnectedState = (network: WalletNetwork): WalletState => ({
+  isConnected: false,
+  address: null,
+  xlmBalance: '0',
+  usdcBalance: '0',
+  isConnecting: false,
+  isFreighterInstalled: false,
+  isRabetInstalled: false,
+  connectedWallet: null,
+  networkPassphrase: null,
+  network,
+  error: null,
+});
+
+async function fetchBalances(address: string, network: WalletNetwork) {
+  try {
+    const response = await fetch(`${HORIZON_URLS[network]}/accounts/${address}`);
+    if (!response.ok) throw new Error('Failed to fetch account data');
+
+    const accountData = await response.json();
+    let xlmBalance = '0';
+    let usdcBalance = '0';
+
+    for (const balance of accountData.balances ?? []) {
+      if (balance.asset_type === 'native') {
+        xlmBalance = Number.parseFloat(balance.balance).toFixed(2);
+      } else if (balance.asset_code === 'USDC') {
+        usdcBalance = Number.parseFloat(balance.balance).toFixed(2);
+      }
+    }
+    return { xlmBalance, usdcBalance };
+  } catch (error) {
+    console.warn('Failed to fetch wallet balances:', error);
+    return { xlmBalance: '0', usdcBalance: '0' };
+  }
+}
 
 export function WalletProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<WalletState>({
-    isConnected: false,
-    address: null,
-    xlmBalance: '0',
-    usdcBalance: '0',
-    isConnecting: false,
-    isFreighterInstalled: false,
-    isRabetInstalled: false,
-    connectedWallet: null,
-    networkPassphrase: null,
-    network: 'mainnet', // Default to mainnet
-  });
+  const [state, setState] = useState<WalletState>(() =>
+    disconnectedState(loadWalletNetwork())
+  );
+  const stateRef = useRef(state);
+  const restoredRef = useRef(false);
 
-  // Get current network configuration
-  const getCurrentNetworkConfig = useCallback(() => {
-    return {
-      passphrase: state.network === 'mainnet' ? STELLAR_MAINNET_PASSPHRASE : STELLAR_TESTNET_PASSPHRASE,
-      horizonUrl: state.network === 'mainnet' ? HORIZON_MAINNET_URL : HORIZON_TESTNET_URL,
-    };
-  }, [state.network]);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
 
-  // Check if wallets are installed
-  const checkWalletInstallation = useCallback(() => {
-    const isFreighterInstalled = typeof window !== 'undefined' && 'freighter' in window;
-    const isRabetInstalled = isRabetAvailable();
-    
-    setState(prev => ({ 
-      ...prev, 
-      isFreighterInstalled: isFreighterInstalled,
-      isRabetInstalled: isRabetInstalled
+  const checkWalletInstallation = useCallback(async () => {
+    const [isFreighterInstalled, isRabetInstalled] = await Promise.all([
+      walletAdapters.freighter.isAvailable(),
+      walletAdapters.rabet.isAvailable(),
+    ]);
+    setState((previous) => ({
+      ...previous,
+      isFreighterInstalled,
+      isRabetInstalled,
     }));
-    
-    return { isFreighterInstalled, isRabetInstalled };
   }, []);
 
-  // Get Freighter API
-  const getFreighter = useCallback((): FreighterModule | null => {
-    if (typeof window === 'undefined' || !window.freighter) {
-      return null;
-    }
-    return window.freighter as FreighterModule;
-  }, []);
-
-  // Get Rabet API
-  const getRabet = useCallback((): RabetModule | null => {
-    if (typeof window === 'undefined' || !window.rabet) {
-      return null;
-    }
-    return window.rabet as RabetModule;
-  }, []);
-
-  // Fetch balances from Horizon API
-  const fetchBalances = useCallback(async (publicKey: string) => {
-    try {
-      const { horizonUrl } = getCurrentNetworkConfig();
-      const response = await fetch(`${horizonUrl}/accounts/${publicKey}`);
-      if (!response.ok) {
-        throw new Error('Failed to fetch account data');
-      }
-      
-      const accountData = await response.json();
-      const balances = accountData.balances;
-      
-      let xlmBalance = '0';
-      let usdcBalance = '0';
-      
-      for (const balance of balances) {
-        if (balance.asset_type === 'native') {
-          xlmBalance = parseFloat(balance.balance).toFixed(2);
-        } else if (balance.asset_code === 'USDC') {
-          usdcBalance = parseFloat(balance.balance).toFixed(2);
-        }
-      }
-      
-      return { xlmBalance, usdcBalance };
-    } catch (error) {
-      console.warn('Failed to fetch balances:', error);
-      return { xlmBalance: '0', usdcBalance: '0' };
-    }
-  }, [getCurrentNetworkConfig]);
-
-  // Connect to wallet (Freighter, Rabet, or auto-detect)
-  const connect = useCallback(async (walletType?: WalletType) => {
-    setState(prev => ({ ...prev, isConnecting: true }));
-    
-    try {
-      let publicKey: string;
-      let networkDetails: any = null;
-      let connectedWalletType: WalletType;
-      const { passphrase } = getCurrentNetworkConfig();
-
-      // If no wallet type specified, try to auto-detect
-      if (!walletType) {
-        const { isFreighterInstalled, isRabetInstalled } = checkWalletInstallation();
-        
-        if (isRabetInstalled) {
-          walletType = 'rabet';
-        } else if (isFreighterInstalled) {
-          walletType = 'freighter';
-        } else {
-          throw new Error('No supported wallet found. Please install Freighter or Rabet wallet.');
-        }
-      }
-
-      // Connect based on wallet type
-      switch (walletType) {
-        case 'rabet':
-          if (!getRabet()) {
-            throw new Error('Rabet wallet is not installed. Please install the Rabet browser extension.');
-          }
-          console.log('Connecting to Rabet wallet...');
-          publicKey = await connectRabet();
-          connectedWalletType = 'rabet';
-          
-          // Set up Rabet event listeners
-          setupRabetEventListeners(
-            () => {
-              console.log('Rabet account changed - refreshing connection...');
-              connect(walletType);
-            },
-            (networkId: string) => {
-              console.log('Rabet network changed to:', networkId);
-              // Handle network change if needed
-            }
-          );
-          break;
-
-        case 'freighter':
-          const freighter = getFreighter();
-          if (!freighter) {
-            throw new Error('Freighter wallet is not installed. Please install Freighter extension.');
-          }
-          
-          console.log('Connecting to Freighter wallet...');
-          
-          // Check if already connected
-          const isAlreadyConnected = await freighter.isConnected();
-          
-          if (isAlreadyConnected) {
-            publicKey = await freighter.getPublicKey();
-          } else {
-            // Request connection
-            publicKey = await freighter.getPublicKey();
-          }
-
-          // Get network details
-          networkDetails = await freighter.getNetworkDetails();
-          connectedWalletType = 'freighter';
-          
-          // Validate network for Freighter
-          if (state.network === 'testnet' && networkDetails.networkPassphrase !== STELLAR_TESTNET_PASSPHRASE) {
-            console.warn('Freighter is not connected to Stellar testnet. Please switch networks in Freighter.');
-          } else if (state.network === 'mainnet' && networkDetails.networkPassphrase !== STELLAR_MAINNET_PASSPHRASE) {
-            console.warn('Freighter is not connected to Stellar mainnet. Please switch networks in Freighter.');
-          }
-          break;
-
-        default:
-          throw new Error(`Unsupported wallet type: ${walletType}`);
-      }
-
-      // Fetch balances
-      const balances = await fetchBalances(publicKey);
-      
-      setState(prev => ({
-        ...prev,
+  const applyConnection = useCallback(
+    async (
+      wallet: WalletType,
+      address: string,
+      network: WalletNetwork,
+      networkPassphrase?: string
+    ) => {
+      const balances = await fetchBalances(address, network);
+      const session: WalletSession = { wallet, address, network };
+      saveWalletSession(session);
+      setState((previous) => ({
+        ...previous,
+        ...balances,
         isConnected: true,
-        address: publicKey,
-        xlmBalance: balances.xlmBalance,
-        usdcBalance: balances.usdcBalance,
         isConnecting: false,
-        connectedWallet: connectedWalletType,
-        networkPassphrase: networkDetails?.networkPassphrase || passphrase,
+        address,
+        connectedWallet: wallet,
+        network,
+        networkPassphrase:
+          networkPassphrase ?? NETWORK_PASSPHRASES[network],
+        error: null,
+      }));
+    },
+    []
+  );
+
+  const connect = useCallback(
+    async (requestedWallet?: WalletType) => {
+      setState((previous) => ({
+        ...previous,
+        isConnecting: true,
+        error: null,
       }));
 
-      // Store connection in localStorage for persistence
-      localStorage.setItem('walletConnected', 'true');
-      localStorage.setItem('walletAddress', publicKey);
-      localStorage.setItem('connectedWallet', connectedWalletType);
-      localStorage.setItem('walletNetwork', state.network);
-      
-      console.log(`Connected to ${connectedWalletType} wallet:`, {
-        address: publicKey,
-        network: state.network,
-        networkPassphrase: networkDetails?.networkPassphrase || passphrase,
-        balances
-      });
-    } catch (error) {
-      console.error('Failed to connect to wallet:', error);
-      setState(prev => ({ 
-        ...prev, 
-        isConnecting: false,
-        isConnected: false,
-        address: null,
-        connectedWallet: null 
-      }));
-      
-      // More specific error handling
-      let errorMessage = 'Failed to connect to wallet';
-      if (error instanceof Error) {
-        if (error.message.includes('User declined') || error.message.includes('rejected')) {
-          errorMessage = 'User declined wallet access';
-        } else if (error.message.includes('No account')) {
-          errorMessage = 'No account found in wallet';
-        } else {
-          errorMessage = error.message;
-        }
-      }
-      
-      throw new Error(errorMessage);
-    }
-  }, [getFreighter, getRabet, fetchBalances, checkWalletInstallation, getCurrentNetworkConfig, state.network]);
-
-  // Disconnect wallet
-  const disconnect = useCallback(async () => {
-    // Disconnect from specific wallet if connected
-    if (state.connectedWallet === 'rabet') {
       try {
-        await disconnectRabet();
-      } catch (error) {
-        console.warn('Error disconnecting from Rabet:', error);
-      }
-    }
-    
-    setState({
-      isConnected: false,
-      address: null,
-      xlmBalance: '0',
-      usdcBalance: '0',
-      isConnecting: false,
-      isFreighterInstalled: state.isFreighterInstalled,
-      isRabetInstalled: state.isRabetInstalled,
-      connectedWallet: null,
-      networkPassphrase: null,
-      network: state.network, // Keep current network setting
-    });
-    
-    // Clear localStorage
-    localStorage.removeItem('walletConnected');
-    localStorage.removeItem('walletAddress');
-    localStorage.removeItem('connectedWallet');
-    
-    console.log('Disconnected from wallet');
-  }, [state.connectedWallet, state.isFreighterInstalled, state.isRabetInstalled, state.network]);
+        let wallet = requestedWallet;
+        if (!wallet) {
+          const availability = await Promise.all(
+            (Object.keys(walletAdapters) as WalletType[]).map(async (type) => ({
+              type,
+              available: await walletAdapters[type].isAvailable(),
+            }))
+          );
+          wallet = availability.find((item) => item.available)?.type;
+        }
+        if (!wallet) throw new Error('No supported wallet provider is available');
 
-  // Sign transaction with connected wallet
-  const signTransaction = useCallback(async (xdr: string): Promise<string> => {
-    if (!state.isConnected || !state.connectedWallet) {
+        const previous = stateRef.current;
+        const connection = await getWalletAdapter(wallet).connect(previous.network);
+
+        if (
+          previous.connectedWallet &&
+          previous.connectedWallet !== wallet
+        ) {
+          await getWalletAdapter(previous.connectedWallet).disconnect(
+            previous.address ?? undefined
+          );
+        }
+
+        await applyConnection(
+          wallet,
+          connection.address,
+          previous.network,
+          connection.networkPassphrase
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to connect wallet';
+        setState((previous) => ({
+          ...previous,
+          isConnecting: false,
+          error: message,
+        }));
+        throw new Error(message);
+      }
+    },
+    [applyConnection]
+  );
+
+  const switchWallet = useCallback(
+    async (walletType: WalletType) => connect(walletType),
+    [connect]
+  );
+
+  const disconnect = useCallback(async () => {
+    const current = stateRef.current;
+    try {
+      if (current.connectedWallet) {
+        await getWalletAdapter(current.connectedWallet).disconnect(
+          current.address ?? undefined
+        );
+      }
+    } catch (error) {
+      console.warn('Wallet provider disconnect failed:', error);
+    } finally {
+      clearWalletSession();
+      setState((previous) => ({
+        ...disconnectedState(previous.network),
+        isFreighterInstalled: previous.isFreighterInstalled,
+        isRabetInstalled: previous.isRabetInstalled,
+      }));
+    }
+  }, []);
+
+  const signTransaction = useCallback(async (xdr: string) => {
+    const current = stateRef.current;
+    if (
+      !current.isConnected ||
+      !current.connectedWallet ||
+      !current.address
+    ) {
       throw new Error('Wallet is not connected');
     }
+    return getWalletAdapter(current.connectedWallet).signTransaction(
+      xdr,
+      current.network,
+      current.address
+    );
+  }, []);
 
-    try {
-      const { passphrase } = getCurrentNetworkConfig();
-      let signedXDR: string;
-
-      switch (state.connectedWallet) {
-        case 'rabet':
-          console.log(`Signing transaction with Rabet on ${state.network}...`);
-          signedXDR = await signWithRabet(xdr, state.network);
-          break;
-
-        case 'freighter':
-          const freighter = getFreighter();
-          if (!freighter) {
-            throw new Error('Freighter wallet is not available');
-          }
-          
-          console.log(`Signing transaction with Freighter on ${state.network}...`);
-          signedXDR = await freighter.signTransaction(xdr, {
-            networkPassphrase: passphrase
-          });
-          break;
-
-        default:
-          throw new Error(`Signing not supported for wallet: ${state.connectedWallet}`);
-      }
-      
-      console.log('Transaction signed successfully');
-      return signedXDR;
-    } catch (error) {
-      console.error('Failed to sign transaction:', error);
-      
-      let errorMessage = 'Failed to sign transaction';
-      if (error instanceof Error) {
-        if (error.message.includes('rejected') || error.message.includes('declined') || error.message.includes('denied')) {
-          errorMessage = 'Transaction rejected by user';
-        } else {
-          errorMessage = error.message;
-        }
-      }
-      
-      throw new Error(errorMessage);
-    }
-  }, [getFreighter, state.isConnected, state.connectedWallet, state.network, getCurrentNetworkConfig]);
-
-  // Refresh balances
   const refreshBalances = useCallback(async () => {
-    if (!state.address) return;
-    
-    try {
-      const balances = await fetchBalances(state.address);
-      setState(prev => ({
-        ...prev,
-        xlmBalance: balances.xlmBalance,
-        usdcBalance: balances.usdcBalance,
-      }));
-    } catch (error) {
-      console.error('Failed to refresh balances:', error);
-    }
-  }, [state.address, fetchBalances]);
+    const current = stateRef.current;
+    if (!current.address) return;
+    const balances = await fetchBalances(current.address, current.network);
+    setState((previous) => ({ ...previous, ...balances }));
+  }, []);
 
-  // Switch network
-  const switchNetwork = useCallback((network: 'mainnet' | 'testnet') => {
-    setState(prev => ({ ...prev, network }));
-    localStorage.setItem('walletNetwork', network);
-    
-    // If connected, refresh balances for new network
-    if (state.address) {
-      refreshBalances();
+  const switchNetwork = useCallback((network: WalletNetwork) => {
+    localStorage.setItem(WALLET_NETWORK_KEY, network);
+    const current = stateRef.current;
+    if (current.connectedWallet && current.address) {
+      saveWalletSession({
+        wallet: current.connectedWallet,
+        address: current.address,
+        network,
+      });
+      void fetchBalances(current.address, network).then((balances) => {
+        setState((previous) => ({
+          ...previous,
+          ...balances,
+          network,
+          networkPassphrase: NETWORK_PASSPHRASES[network],
+        }));
+      });
+    } else {
+      setState((previous) => ({ ...previous, network }));
     }
-    
-    console.log(`Switched to ${network}`);
-  }, [state.address, refreshBalances]);
+  }, []);
 
-  // Auto-reconnect on page load
   useEffect(() => {
-    const autoReconnect = async () => {
-      checkWalletInstallation();
-      
-      const wasConnected = localStorage.getItem('walletConnected') === 'true';
-      const savedAddress = localStorage.getItem('walletAddress');
-      const savedWallet = localStorage.getItem('connectedWallet') as WalletType;
-      const savedNetwork = localStorage.getItem('walletNetwork') as 'mainnet' | 'testnet';
-      
-      // Restore network setting
-      if (savedNetwork) {
-        setState(prev => ({ ...prev, network: savedNetwork }));
-      }
-      
-      if (wasConnected && savedAddress && savedWallet) {
-        try {
-          // Check if the wallet is still available and connected
-          if (savedWallet === 'freighter') {
-            const freighter = getFreighter();
-            if (freighter) {
-              const isStillConnected = await freighter.isConnected();
-              if (isStillConnected) {
-                await connect(savedWallet);
-              } else {
-                disconnect();
-              }
-            } else {
-              disconnect();
-            }
-          } else if (savedWallet === 'rabet') {
-            if (isRabetAvailable()) {
-              // For Rabet, we'll try to reconnect directly since it doesn't have an isConnected method
-              await connect(savedWallet);
-            } else {
-              disconnect();
-            }
-          }
-        } catch (error) {
-          console.warn('Failed to auto-reconnect:', error);
-          disconnect();
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    void checkWalletInstallation();
+
+    const session = loadWalletSession();
+    if (!session) return;
+
+    setState((previous) => ({ ...previous, isConnecting: true }));
+    void getWalletAdapter(session.wallet)
+      .restore(session)
+      .then(async (connection) => {
+        if (!connection) {
+          clearWalletSession();
+          setState((previous) => ({
+            ...disconnectedState(session.network),
+            isFreighterInstalled: previous.isFreighterInstalled,
+            isRabetInstalled: previous.isRabetInstalled,
+          }));
+          return;
         }
-      }
-    };
+        await applyConnection(
+          session.wallet,
+          connection.address,
+          session.network,
+          connection.networkPassphrase
+        );
+      })
+      .catch((error) => {
+        console.warn('Failed to restore wallet session:', error);
+        clearWalletSession();
+        setState((previous) => ({
+          ...disconnectedState(session.network),
+          isFreighterInstalled: previous.isFreighterInstalled,
+          isRabetInstalled: previous.isRabetInstalled,
+        }));
+      });
+  }, [applyConnection, checkWalletInstallation]);
 
-    autoReconnect();
-  }, [connect, disconnect, checkWalletInstallation, getFreighter]);
-
-  // Periodic balance refresh
   useEffect(() => {
     if (!state.isConnected || !state.address) return;
-
-    const interval = setInterval(refreshBalances, 30000); // Refresh every 30 seconds
-    return () => clearInterval(interval);
+    const interval = window.setInterval(() => void refreshBalances(), 30_000);
+    return () => window.clearInterval(interval);
   }, [state.isConnected, state.address, refreshBalances]);
 
   return (
-    <WalletContext.Provider value={{ 
-      ...state, 
-      publicKey: state.address, // Provide publicKey as alias for address
-      connect, 
-      disconnect, 
-      signTransaction, 
-      refreshBalances,
-      switchNetwork 
-    }}>
+    <WalletContext.Provider
+      value={{
+        ...state,
+        publicKey: state.address,
+        connect,
+        switchWallet,
+        disconnect,
+        signTransaction,
+        refreshBalances,
+        switchNetwork,
+      }}
+    >
       {children}
     </WalletContext.Provider>
   );
@@ -444,16 +330,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 
 export function useWallet() {
   const context = useContext(WalletContext);
-  if (context === undefined) {
+  if (!context) {
     throw new Error('useWallet must be used within a WalletProvider');
   }
   return context;
-}
-
-// Type augmentation for window objects
-declare global {
-  interface Window {
-    freighter?: FreighterModule;
-    rabet?: RabetModule;
-  }
 }

--- a/frontend/src/types/wallet.ts
+++ b/frontend/src/types/wallet.ts
@@ -5,7 +5,7 @@ export interface RabetModule {
   disconnect(): Promise<void>;
   isUnlocked(): Promise<boolean>;
   close(): Promise<void>;
-  on(event: 'accountChanged' | 'networkChanged', handler: (data?: any) => void): void;
+  on(event: 'accountChanged' | 'networkChanged', handler: (data?: unknown) => void): void;
 }
 
 export interface RabetConnectResult {
@@ -26,13 +26,40 @@ export interface FreighterModule {
 }
 
 export interface WalletInfo {
-  id: string;
+  id: WalletType;
   name: string;
   type: 'extension' | 'web';
   available: boolean;
 }
 
 export type WalletType = 'freighter' | 'rabet' | 'albedo';
+export type WalletNetwork = 'mainnet' | 'testnet';
+
+export interface WalletConnection {
+  address: string;
+  networkPassphrase?: string;
+}
+
+export interface WalletSession {
+  wallet: WalletType;
+  address: string;
+  network: WalletNetwork;
+}
+
+export interface WalletAdapter {
+  id: WalletType;
+  name: string;
+  type: 'extension' | 'web';
+  isAvailable(): Promise<boolean>;
+  connect(network: WalletNetwork): Promise<WalletConnection>;
+  restore(session: WalletSession): Promise<WalletConnection | null>;
+  disconnect(address?: string): Promise<void>;
+  signTransaction(
+    xdr: string,
+    network: WalletNetwork,
+    address: string
+  ): Promise<string>;
+}
 
 // Global window type extensions
 declare global {

--- a/frontend/src/wallet/detectStellarWallets.ts
+++ b/frontend/src/wallet/detectStellarWallets.ts
@@ -1,49 +1,8 @@
-import { isConnected } from "@stellar/freighter-api";
 import { WalletInfo } from "@/types/wallet";
+import { detectWalletProviders } from "@/wallet/providers";
 
 export async function detectWallets(): Promise<WalletInfo[]> {
-  const wallets: WalletInfo[] = [];
-
-  // Check for Freighter wallet
-  try {
-    const freighterAvailable = typeof window !== 'undefined' && 'freighter' in window;
-    if (freighterAvailable) {
-      const isFreighterConnected = await isConnected();
-      wallets.push({
-        id: "freighter",
-        name: "Freighter",
-        type: "extension",
-        available: isFreighterConnected
-      });
-    }
-  } catch (error) {
-    console.warn('Error checking Freighter availability:', error);
-  }
-
-  // Check for Rabet wallet
-  try {
-    const rabetAvailable = typeof window !== 'undefined' && 'rabet' in window;
-    if (rabetAvailable) {
-      wallets.push({
-        id: "rabet",
-        name: "Rabet",
-        type: "extension",
-        available: true
-      });
-    }
-  } catch (error) {
-    console.warn('Error checking Rabet availability:', error);
-  }
-
-  // Albedo is always available as a web wallet
-  wallets.push({
-    id: "albedo",
-    name: "Albedo",
-    type: "web",
-    available: true
-  });
-
-  return wallets;
+  return detectWalletProviders();
 }
 
 export function isRabetDetected(): boolean {

--- a/frontend/src/wallet/providers.test.ts
+++ b/frontend/src/wallet/providers.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const freighterMocks = vi.hoisted(() => ({
+  getAddress: vi.fn(),
+  getNetworkDetails: vi.fn(),
+  isAllowed: vi.fn(),
+  isConnected: vi.fn(),
+  requestAccess: vi.fn(),
+  signTransaction: vi.fn(),
+}));
+
+const albedoMocks = vi.hoisted(() => ({
+  implicitFlow: vi.fn(),
+  listImplicitSessions: vi.fn(),
+  forgetImplicitSession: vi.fn(),
+  tx: vi.fn(),
+}));
+
+vi.mock('@stellar/freighter-api', () => freighterMocks);
+vi.mock('@albedo-link/intent', () => ({ default: albedoMocks }));
+vi.mock('@/wallet/connectRabet', () => ({
+  connectRabet: vi.fn(),
+  disconnectRabet: vi.fn(),
+  isRabetAvailable: vi.fn(() => false),
+  isRabetUnlocked: vi.fn(() => false),
+  signWithRabet: vi.fn(),
+}));
+
+import {
+  albedoAdapter,
+  freighterAdapter,
+  getWalletAdapter,
+  NETWORK_PASSPHRASES,
+  normalizeWalletError,
+  walletAdapters,
+} from '@/wallet/providers';
+
+describe('wallet provider abstraction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers three supported providers', () => {
+    expect(Object.keys(walletAdapters)).toEqual([
+      'freighter',
+      'rabet',
+      'albedo',
+    ]);
+    expect(getWalletAdapter('albedo')).toBe(albedoAdapter);
+  });
+
+  it('connects Albedo with a refresh-restorable implicit session', async () => {
+    albedoMocks.implicitFlow.mockResolvedValue({
+      granted: true,
+      pubkey: 'GALBEDO',
+    });
+
+    await expect(albedoAdapter.connect('testnet')).resolves.toEqual({
+      address: 'GALBEDO',
+      networkPassphrase: NETWORK_PASSPHRASES.testnet,
+    });
+    expect(albedoMocks.implicitFlow).toHaveBeenCalledWith({
+      intents: ['tx'],
+      network: NETWORK_PASSPHRASES.testnet,
+    });
+  });
+
+  it('restores, signs, and disconnects an Albedo session', async () => {
+    albedoMocks.listImplicitSessions.mockReturnValue([
+      { pubkey: 'GALBEDO', grants: ['tx'] },
+    ]);
+    albedoMocks.tx.mockResolvedValue({
+      signed_envelope_xdr: 'SIGNED_XDR',
+    });
+
+    const session = {
+      wallet: 'albedo' as const,
+      address: 'GALBEDO',
+      network: 'mainnet' as const,
+    };
+
+    await expect(albedoAdapter.restore(session)).resolves.toEqual({
+      address: 'GALBEDO',
+      networkPassphrase: NETWORK_PASSPHRASES.mainnet,
+    });
+    await expect(
+      albedoAdapter.signTransaction('XDR', 'mainnet', 'GALBEDO')
+    ).resolves.toBe('SIGNED_XDR');
+
+    await albedoAdapter.disconnect('GALBEDO');
+    expect(albedoMocks.forgetImplicitSession).toHaveBeenCalledWith('GALBEDO');
+  });
+
+  it('connects and signs through the Freighter adapter', async () => {
+    freighterMocks.requestAccess.mockResolvedValue({ address: 'GFREIGHTER' });
+    freighterMocks.getNetworkDetails.mockResolvedValue({
+      networkPassphrase: NETWORK_PASSPHRASES.testnet,
+    });
+    freighterMocks.signTransaction.mockResolvedValue({
+      signedTxXdr: 'SIGNED_XDR',
+      signerAddress: 'GFREIGHTER',
+    });
+
+    await expect(freighterAdapter.connect('testnet')).resolves.toEqual({
+      address: 'GFREIGHTER',
+      networkPassphrase: NETWORK_PASSPHRASES.testnet,
+    });
+    await expect(
+      freighterAdapter.signTransaction('XDR', 'testnet', 'GFREIGHTER')
+    ).resolves.toBe('SIGNED_XDR');
+  });
+
+  it('normalizes user rejection errors', () => {
+    expect(
+      normalizeWalletError({ message: 'Action rejected by user' }, 'sign')
+        .message
+    ).toBe('Transaction rejected by user');
+  });
+});

--- a/frontend/src/wallet/providers.ts
+++ b/frontend/src/wallet/providers.ts
@@ -1,0 +1,256 @@
+import albedo from '@albedo-link/intent';
+import {
+  getAddress,
+  getNetworkDetails,
+  isAllowed,
+  isConnected,
+  requestAccess,
+  signTransaction as signWithFreighter,
+} from '@stellar/freighter-api';
+import {
+  WalletAdapter,
+  WalletNetwork,
+  WalletSession,
+  WalletType,
+} from '@/types/wallet';
+import {
+  connectRabet,
+  disconnectRabet,
+  isRabetAvailable,
+  isRabetUnlocked,
+  signWithRabet,
+} from '@/wallet/connectRabet';
+
+export const NETWORK_PASSPHRASES: Record<WalletNetwork, string> = {
+  mainnet: 'Public Global Stellar Network ; September 2015',
+  testnet: 'Test SDF Network ; September 2015',
+};
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error && 'message' in error) {
+    return String(error.message);
+  }
+  return 'Unknown wallet error';
+}
+
+export function normalizeWalletError(
+  error: unknown,
+  action: 'connect' | 'sign' | 'restore' = 'connect'
+): Error {
+  const message = errorMessage(error);
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes('reject') ||
+    lower.includes('declin') ||
+    lower.includes('denied') ||
+    lower.includes('closed')
+  ) {
+    return new Error(
+      action === 'sign'
+        ? 'Transaction rejected by user'
+        : 'Wallet connection rejected by user'
+    );
+  }
+
+  return new Error(message || `Failed to ${action} wallet`);
+}
+
+function assertFreighterResult<T extends { error?: { message?: string } }>(
+  result: T
+): T {
+  if (result.error) {
+    throw new Error(result.error.message || 'Freighter request failed');
+  }
+  return result;
+}
+
+export const freighterAdapter: WalletAdapter = {
+  id: 'freighter',
+  name: 'Freighter',
+  type: 'extension',
+  async isAvailable() {
+    try {
+      return assertFreighterResult(await isConnected()).isConnected;
+    } catch {
+      return false;
+    }
+  },
+  async connect(network) {
+    try {
+      const access = assertFreighterResult(await requestAccess());
+      if (!access.address) throw new Error('No account found in Freighter');
+      const details = assertFreighterResult(await getNetworkDetails());
+      if (details.networkPassphrase !== NETWORK_PASSPHRASES[network]) {
+        throw new Error(
+          `Freighter is not connected to Stellar ${network}. Switch networks in Freighter and try again.`
+        );
+      }
+      return {
+        address: access.address,
+        networkPassphrase: details.networkPassphrase,
+      };
+    } catch (error) {
+      throw normalizeWalletError(error);
+    }
+  },
+  async restore(session) {
+    try {
+      const connected = assertFreighterResult(await isConnected());
+      const allowed = assertFreighterResult(await isAllowed());
+      if (!connected.isConnected || !allowed.isAllowed) return null;
+
+      const account = assertFreighterResult(await getAddress());
+      if (!account.address || account.address !== session.address) return null;
+      const details = assertFreighterResult(await getNetworkDetails());
+      if (
+        details.networkPassphrase !== NETWORK_PASSPHRASES[session.network]
+      ) {
+        return null;
+      }
+      return {
+        address: account.address,
+        networkPassphrase: details.networkPassphrase,
+      };
+    } catch {
+      return null;
+    }
+  },
+  async disconnect() {
+    // Freighter does not expose an application-level disconnect API.
+  },
+  async signTransaction(xdr, network, address) {
+    try {
+      const result = assertFreighterResult(
+        await signWithFreighter(xdr, {
+          address,
+          networkPassphrase: NETWORK_PASSPHRASES[network],
+        })
+      );
+      if (!result.signedTxXdr) {
+        throw new Error('Freighter returned an empty signed transaction');
+      }
+      return result.signedTxXdr;
+    } catch (error) {
+      throw normalizeWalletError(error, 'sign');
+    }
+  },
+};
+
+export const rabetAdapter: WalletAdapter = {
+  id: 'rabet',
+  name: 'Rabet',
+  type: 'extension',
+  async isAvailable() {
+    return isRabetAvailable();
+  },
+  async connect() {
+    try {
+      return { address: await connectRabet() };
+    } catch (error) {
+      throw normalizeWalletError(error);
+    }
+  },
+  async restore(session) {
+    if (!isRabetAvailable() || !(await isRabetUnlocked())) return null;
+    try {
+      const address = await connectRabet();
+      return address === session.address ? { address } : null;
+    } catch {
+      return null;
+    }
+  },
+  async disconnect() {
+    await disconnectRabet();
+  },
+  async signTransaction(xdr, network) {
+    try {
+      return await signWithRabet(xdr, network);
+    } catch (error) {
+      throw normalizeWalletError(error, 'sign');
+    }
+  },
+};
+
+export const albedoAdapter: WalletAdapter = {
+  id: 'albedo',
+  name: 'Albedo',
+  type: 'web',
+  async isAvailable() {
+    return typeof window !== 'undefined';
+  },
+  async connect(network) {
+    try {
+      const result = await albedo.implicitFlow({
+        intents: ['tx'],
+        network: NETWORK_PASSPHRASES[network],
+      });
+      if (!result.granted || !result.pubkey) {
+        throw new Error('Albedo connection was not granted');
+      }
+      return {
+        address: result.pubkey,
+        networkPassphrase: NETWORK_PASSPHRASES[network],
+      };
+    } catch (error) {
+      throw normalizeWalletError(error);
+    }
+  },
+  async restore(session) {
+    const activeSession = albedo
+      .listImplicitSessions()
+      .find(
+        (item) =>
+          item.pubkey === session.address && item.grants.includes('tx')
+      );
+    return activeSession
+      ? {
+          address: session.address,
+          networkPassphrase: NETWORK_PASSPHRASES[session.network],
+        }
+      : null;
+  },
+  async disconnect(address) {
+    if (address) albedo.forgetImplicitSession(address);
+  },
+  async signTransaction(xdr, network, address) {
+    try {
+      const result = await albedo.tx({
+        xdr,
+        pubkey: address,
+        network: NETWORK_PASSPHRASES[network],
+        submit: false,
+      });
+      if (!result.signed_envelope_xdr) {
+        throw new Error('Albedo returned an empty signed transaction');
+      }
+      return result.signed_envelope_xdr;
+    } catch (error) {
+      throw normalizeWalletError(error, 'sign');
+    }
+  },
+};
+
+export const walletAdapters: Record<WalletType, WalletAdapter> = {
+  freighter: freighterAdapter,
+  rabet: rabetAdapter,
+  albedo: albedoAdapter,
+};
+
+export function getWalletAdapter(type: WalletType): WalletAdapter {
+  const adapter = walletAdapters[type];
+  if (!adapter) throw new Error(`Unsupported wallet type: ${type}`);
+  return adapter;
+}
+
+export async function detectWalletProviders() {
+  return Promise.all(
+    Object.values(walletAdapters).map(async (adapter) => ({
+      id: adapter.id,
+      name: adapter.name,
+      type: adapter.type,
+      available: await adapter.isAvailable(),
+    }))
+  );
+}

--- a/frontend/src/wallet/session.test.ts
+++ b/frontend/src/wallet/session.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearWalletSession,
+  loadWalletNetwork,
+  loadWalletSession,
+  saveWalletSession,
+  WALLET_NETWORK_KEY,
+  WALLET_SESSION_KEY,
+} from '@/wallet/session';
+
+describe('wallet session persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists and restores the selected provider, address, and network', () => {
+    const session = {
+      wallet: 'albedo' as const,
+      address: 'GTESTADDRESS',
+      network: 'testnet' as const,
+    };
+
+    saveWalletSession(session);
+
+    expect(loadWalletSession()).toEqual(session);
+    expect(loadWalletNetwork()).toBe('testnet');
+  });
+
+  it('clears malformed persisted sessions', () => {
+    localStorage.setItem(
+      WALLET_SESSION_KEY,
+      JSON.stringify({ wallet: 'unknown', address: '', network: 'testnet' })
+    );
+
+    expect(loadWalletSession()).toBeNull();
+    expect(localStorage.getItem(WALLET_SESSION_KEY)).toBeNull();
+  });
+
+  it('uses mainnet when the persisted network is invalid', () => {
+    localStorage.setItem(WALLET_NETWORK_KEY, 'invalid');
+    expect(loadWalletNetwork()).toBe('mainnet');
+  });
+
+  it('removes current and legacy session keys on disconnect', () => {
+    localStorage.setItem(WALLET_SESSION_KEY, '{}');
+    localStorage.setItem('walletConnected', 'true');
+    localStorage.setItem('walletAddress', 'GTESTADDRESS');
+    localStorage.setItem('connectedWallet', 'rabet');
+
+    clearWalletSession();
+
+    expect(localStorage.getItem(WALLET_SESSION_KEY)).toBeNull();
+    expect(localStorage.getItem('walletConnected')).toBeNull();
+    expect(localStorage.getItem('walletAddress')).toBeNull();
+    expect(localStorage.getItem('connectedWallet')).toBeNull();
+  });
+});

--- a/frontend/src/wallet/session.ts
+++ b/frontend/src/wallet/session.ts
@@ -1,0 +1,49 @@
+import { WalletNetwork, WalletSession, WalletType } from '@/types/wallet';
+
+export const WALLET_SESSION_KEY = 'oryn.wallet.session.v1';
+export const WALLET_NETWORK_KEY = 'walletNetwork';
+
+const walletTypes: WalletType[] = ['freighter', 'rabet', 'albedo'];
+const networks: WalletNetwork[] = ['mainnet', 'testnet'];
+
+export function saveWalletSession(session: WalletSession): void {
+  localStorage.setItem(WALLET_SESSION_KEY, JSON.stringify(session));
+  localStorage.setItem(WALLET_NETWORK_KEY, session.network);
+}
+
+export function loadWalletSession(): WalletSession | null {
+  try {
+    const raw = localStorage.getItem(WALLET_SESSION_KEY);
+    if (!raw) return null;
+
+    const session = JSON.parse(raw) as WalletSession;
+    if (
+      !walletTypes.includes(session.wallet) ||
+      !networks.includes(session.network) ||
+      typeof session.address !== 'string' ||
+      session.address.length === 0
+    ) {
+      clearWalletSession();
+      return null;
+    }
+
+    return session;
+  } catch {
+    clearWalletSession();
+    return null;
+  }
+}
+
+export function loadWalletNetwork(): WalletNetwork {
+  const network = localStorage.getItem(WALLET_NETWORK_KEY);
+  return networks.includes(network as WalletNetwork)
+    ? (network as WalletNetwork)
+    : 'mainnet';
+}
+
+export function clearWalletSession(): void {
+  localStorage.removeItem(WALLET_SESSION_KEY);
+  localStorage.removeItem('walletConnected');
+  localStorage.removeItem('walletAddress');
+  localStorage.removeItem('connectedWallet');
+}


### PR DESCRIPTION
Summary
introduce a wallet adapter layer shared by Freighter, Rabet, and Albedo
add connect, disconnect, provider switching, and normalized provider errors
persist the selected provider, account, and network and validate provider sessions during refresh restoration
add Albedo implicit-session transaction signing and explicit Freighter network validation
add focused provider and session persistence tests
User impact
Users can choose among three Stellar wallet providers, switch providers from the connected-wallet menu, and retain valid wallet state across page refreshes.

Validation
npm test -- --run src/wallet/providers.test.ts src/wallet/session.test.ts (9 tests passed)
changed-file ESLint (0 errors; one existing Fast Refresh export warning in WalletContext)
isolated esbuild production bundle for changed wallet entry points
git diff --check
Repository baseline issues
full npm test cannot resolve the existing missing @/services/marketService module from src/test/services.test.ts
full npm run build is blocked by pre-existing mismatched JSX tags in src/pages/MarketDetail.tsx
full npm run lint reports existing errors across unrelated frontend files
Closes #196