### PR TITLE
Implement notification and alert engine

### DIFF
--- a/backend/__tests__/services/notificationService.test.js
+++ b/backend/__tests__/services/notificationService.test.js
@@ -1,0 +1,120 @@
+jest.mock('../../src/services/pushNotificationService', () => ({
+  sendToWallet: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock('../../src/services/websocketHandler', () => ({
+  sendUserNotification: jest.fn()
+}));
+
+jest.mock('../../src/config/logger', () => ({
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn()
+}));
+
+const notificationService = require('../../src/services/notificationService');
+const pushNotificationService = require('../../src/services/pushNotificationService');
+const websocketHandler = require('../../src/services/websocketHandler');
+
+describe('NotificationService', () => {
+  const walletAddress = 'GABC123';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    notificationService.resetMemoryStore();
+  });
+
+  it('returns default preferences for a new wallet', async () => {
+    const preferences = await notificationService.getPreferences(walletAddress);
+
+    expect(preferences).toMatchObject({
+      transactionStatus: true,
+      treasuryAlerts: true,
+      riskAlerts: true,
+      yieldOpportunityAlerts: true
+    });
+  });
+
+  it('sanitizes preference updates and keeps liquidation warnings enabled', async () => {
+    const preferences = await notificationService.savePreferences(walletAddress, {
+      transactionStatus: false,
+      liquidationWarnings: false,
+      riskAlerts: 'yes'
+    });
+
+    expect(preferences.transactionStatus).toBe(false);
+    expect(preferences.liquidationWarnings).toBe(true);
+    expect(preferences.riskAlerts).toBe(true);
+  });
+
+  it('stores delivered notification history and emits live channels', async () => {
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'transaction_status',
+      title: 'Transaction confirmed',
+      message: 'Trade tx_1 confirmed',
+      severity: 'success',
+      metadata: { transactionId: 'tx_1' }
+    });
+
+    const history = await notificationService.listNotifications(walletAddress);
+
+    expect(result.success).toBe(true);
+    expect(history.notifications).toHaveLength(1);
+    expect(history.notifications[0]).toMatchObject({
+      type: 'transaction_status',
+      category: 'transaction',
+      read: false
+    });
+    expect(websocketHandler.sendUserNotification).toHaveBeenCalledWith(
+      walletAddress.toLowerCase(),
+      expect.objectContaining({ type: 'transaction_status' })
+    );
+    expect(pushNotificationService.sendToWallet).toHaveBeenCalled();
+  });
+
+  it('suppresses disabled alert types without increasing unread badge count', async () => {
+    await notificationService.savePreferences(walletAddress, { yieldOpportunityAlerts: false });
+
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'yield_opportunity',
+      title: 'Yield opportunity',
+      message: 'A pool is yielding 12% APY'
+    });
+
+    const count = await notificationService.unreadCount(walletAddress);
+    const history = await notificationService.listNotifications(walletAddress);
+
+    expect(result.success).toBe(false);
+    expect(result.notification.status).toBe('suppressed');
+    expect(count).toBe(0);
+    expect(history.notifications).toHaveLength(1);
+    expect(websocketHandler.sendUserNotification).not.toHaveBeenCalled();
+  });
+
+  it('marks notifications as read and clears history', async () => {
+    const first = await notificationService.createNotification({
+      walletAddress,
+      type: 'treasury_alert',
+      title: 'Treasury alert',
+      message: 'Large outflow detected'
+    });
+    await notificationService.createNotification({
+      walletAddress,
+      type: 'risk_alert',
+      title: 'Risk alert',
+      message: 'Risk score increased'
+    });
+
+    await notificationService.markRead(walletAddress, first.notification.id);
+    expect(await notificationService.unreadCount(walletAddress)).toBe(1);
+
+    await notificationService.markAllRead(walletAddress);
+    expect(await notificationService.unreadCount(walletAddress)).toBe(0);
+
+    expect(await notificationService.clearNotifications(walletAddress)).toBe(2);
+    const history = await notificationService.listNotifications(walletAddress);
+    expect(history.notifications).toHaveLength(0);
+  });
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -27,6 +27,7 @@ const adminRoutes = require('./src/routes/admin');
 const oracleRoutes = require('./src/routes/oracle');
 const liquidityRoutes = require('./src/routes/liquidity');
 const pushNotificationRoutes = require('./src/routes/pushNotifications');
+const notificationRoutes = require('./src/routes/notifications');
 const marketDepthRoutes = require('./src/routes/marketDepth');
 const crossChainRoutes = require('./src/routes/crossChain');
 const insuranceRoutes = require('./src/routes/insurance');
@@ -267,6 +268,7 @@ class OrynBackendServer {
 
     // Push notification routes
     this.app.use('/api/push', pushNotificationRoutes);
+    this.app.use('/api/notifications', notificationRoutes);
 
     // Explorer deep-linking routes (Issue #83)
     this.app.use('/api/explorer', explorerRoutes);

--- a/backend/src/controllers/notificationController.js
+++ b/backend/src/controllers/notificationController.js
@@ -1,0 +1,183 @@
+const notificationService = require('../services/notificationService');
+const { ForbiddenError, NotFoundError, ValidationError } = require('../middleware/errorHandler');
+
+function assertWalletAccess(req, walletAddress) {
+  const requested = String(walletAddress || '').toLowerCase();
+  const authenticated = req.user?.walletAddress?.toLowerCase();
+
+  if (!requested) {
+    throw new ValidationError('walletAddress is required');
+  }
+
+  if (requested !== authenticated) {
+    throw new ForbiddenError('Cannot access notifications for another wallet');
+  }
+
+  return requested;
+}
+
+class NotificationController {
+  static async getPreferences(req, res) {
+    const walletAddress = assertWalletAccess(req, req.params.walletAddress);
+    const preferences = await notificationService.getPreferences(walletAddress);
+    res.json({ success: true, data: preferences });
+  }
+
+  static async savePreferences(req, res) {
+    const walletAddress = assertWalletAccess(req, req.params.walletAddress);
+    const preferences = await notificationService.savePreferences(walletAddress, req.body);
+    res.json({ success: true, data: preferences, message: 'Notification preferences saved' });
+  }
+
+  static async getAlerts(req, res) {
+    const walletAddress = assertWalletAccess(req, req.params.walletAddress);
+    const data = await notificationService.listNotifications(walletAddress, req.query);
+    res.json({ success: true, data: data.notifications, pagination: data.pagination });
+  }
+
+  static async getUnreadCount(req, res) {
+    const walletAddress = assertWalletAccess(req, req.params.walletAddress);
+    const count = await notificationService.unreadCount(walletAddress);
+    res.json({ success: true, data: { count } });
+  }
+
+  static async markAlertAsRead(req, res) {
+    const notification = await notificationService.markRead(req.user.walletAddress, req.params.alertId);
+    if (!notification) throw new NotFoundError('Notification');
+    res.json({ success: true, data: notification });
+  }
+
+  static async markAllAlertsAsRead(req, res) {
+    const modifiedCount = await notificationService.markAllRead(req.user.walletAddress);
+    res.json({ success: true, data: { modifiedCount } });
+  }
+
+  static async deleteAlert(req, res) {
+    const deleted = await notificationService.deleteNotification(req.user.walletAddress, req.params.alertId);
+    if (!deleted) throw new NotFoundError('Notification');
+    res.json({ success: true, data: { deleted: true } });
+  }
+
+  static async clearAlerts(req, res) {
+    const deletedCount = await notificationService.clearNotifications(req.user.walletAddress);
+    res.json({ success: true, data: { deletedCount } });
+  }
+
+  static async sendTransactionStatusAlert(req, res) {
+    const { walletAddress, transactionId, status, type, amount } = req.body;
+    assertWalletAccess(req, walletAddress);
+    if (!transactionId || !status || !type) throw new ValidationError('transactionId, status, and type are required');
+
+    const severity = status === 'failed' ? 'warning' : status === 'confirmed' ? 'success' : 'info';
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'transaction_status',
+      severity,
+      title: `Transaction ${status}`,
+      message: `${type} transaction ${transactionId} is ${status}${amount ? ` for ${amount}` : ''}.`,
+      metadata: { transactionId, status, transactionType: type, amount }
+    });
+    res.status(201).json({ success: true, data: result });
+  }
+
+  static async sendPortfolioMilestoneAlert(req, res) {
+    const { walletAddress, milestone, value, currentValue } = req.body;
+    assertWalletAccess(req, walletAddress);
+    if (!milestone || value === undefined || currentValue === undefined) throw new ValidationError('milestone, value, and currentValue are required');
+
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'portfolio_milestone',
+      severity: 'success',
+      title: 'Portfolio milestone reached',
+      message: `${milestone} reached. Current value: ${currentValue}; target: ${value}.`,
+      metadata: { milestone, value, currentValue }
+    });
+    res.status(201).json({ success: true, data: result });
+  }
+
+  static async sendLiquidationWarning(req, res) {
+    const { walletAddress, positionId, riskLevel, estimatedLiquidationPrice, currentPrice } = req.body;
+    assertWalletAccess(req, walletAddress);
+    if (!positionId || riskLevel === undefined || !estimatedLiquidationPrice || !currentPrice) {
+      throw new ValidationError('positionId, riskLevel, estimatedLiquidationPrice, and currentPrice are required');
+    }
+
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'liquidation_warning',
+      severity: 'critical',
+      title: 'Liquidation risk warning',
+      message: `Position ${positionId} has reached ${(Number(riskLevel) * 100).toFixed(0)}% risk. Current price: ${currentPrice}; estimated liquidation: ${estimatedLiquidationPrice}.`,
+      metadata: { positionId, riskLevel, estimatedLiquidationPrice, currentPrice },
+      force: true
+    });
+    res.status(201).json({ success: true, data: result });
+  }
+
+  static async sendTreasuryAlert(req, res) {
+    const { walletAddress, eventType, amount, asset = 'USDC', threshold, message } = req.body;
+    assertWalletAccess(req, walletAddress);
+    if (!eventType) throw new ValidationError('eventType is required');
+
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'treasury_alert',
+      severity: Number(amount) >= Number(threshold || Infinity) ? 'warning' : 'info',
+      title: 'Treasury alert',
+      message: message || `Treasury ${eventType} event${amount ? ` for ${amount} ${asset}` : ''}.`,
+      metadata: { eventType, amount, asset, threshold }
+    });
+    res.status(201).json({ success: true, data: result });
+  }
+
+  static async sendRiskAlert(req, res) {
+    const { walletAddress, riskType, score, severity, message, metadata = {} } = req.body;
+    assertWalletAccess(req, walletAddress);
+    if (!riskType) throw new ValidationError('riskType is required');
+
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'risk_alert',
+      severity: severity || (Number(score) >= 80 ? 'critical' : Number(score) >= 60 ? 'warning' : 'info'),
+      title: 'Risk alert',
+      message: message || `${riskType} risk score changed to ${score}.`,
+      metadata: { riskType, score, ...metadata }
+    });
+    res.status(201).json({ success: true, data: result });
+  }
+
+  static async sendYieldOpportunity(req, res) {
+    const { walletAddress, marketId, question, apy, riskScore, message } = req.body;
+    assertWalletAccess(req, walletAddress);
+    if (!marketId || apy === undefined) throw new ValidationError('marketId and apy are required');
+
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'yield_opportunity',
+      severity: Number(riskScore) >= 70 ? 'warning' : 'info',
+      title: 'Yield opportunity',
+      message: message || `${question || marketId} is offering ${apy}% APY.`,
+      metadata: { marketId, question, apy, riskScore }
+    });
+    res.status(201).json({ success: true, data: result });
+  }
+
+  static async logAlertFailure(req, res) {
+    const { walletAddress, alertType, reason, metadata = {} } = req.body;
+    assertWalletAccess(req, walletAddress);
+    if (!alertType || !reason) throw new ValidationError('alertType and reason are required');
+
+    const result = await notificationService.createNotification({
+      walletAddress,
+      type: 'system',
+      severity: 'warning',
+      title: 'Notification delivery issue',
+      message: `${alertType} delivery failed: ${reason}`,
+      metadata: { alertType, reason, ...metadata }
+    });
+    res.status(201).json({ success: true, data: result });
+  }
+}
+
+module.exports = NotificationController;

--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -1,0 +1,115 @@
+const mongoose = require('mongoose');
+
+const notificationSchema = new mongoose.Schema({
+  notificationId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  walletAddress: {
+    type: String,
+    required: true,
+    index: true
+  },
+  type: {
+    type: String,
+    enum: [
+      'transaction_status',
+      'treasury_alert',
+      'risk_alert',
+      'yield_opportunity',
+      'portfolio_milestone',
+      'liquidation_warning',
+      'market_expired',
+      'governance_update',
+      'system'
+    ],
+    required: true,
+    index: true
+  },
+  category: {
+    type: String,
+    enum: ['transaction', 'treasury', 'risk', 'yield', 'portfolio', 'market', 'governance', 'system'],
+    required: true,
+    index: true
+  },
+  severity: {
+    type: String,
+    enum: ['info', 'success', 'warning', 'critical'],
+    default: 'info',
+    index: true
+  },
+  title: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 160
+  },
+  message: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 1000
+  },
+  status: {
+    type: String,
+    enum: ['delivered', 'suppressed', 'failed'],
+    default: 'delivered',
+    index: true
+  },
+  readAt: {
+    type: Date,
+    default: null,
+    index: true
+  },
+  metadata: {
+    type: mongoose.Schema.Types.Mixed,
+    default: {}
+  },
+  delivery: {
+    inApp: {
+      type: Boolean,
+      default: true
+    },
+    pushAttempted: {
+      type: Boolean,
+      default: false
+    },
+    pushDelivered: {
+      type: Boolean,
+      default: false
+    },
+    failureReason: {
+      type: String,
+      default: null
+    }
+  }
+}, {
+  timestamps: true,
+  collection: 'notifications',
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+});
+
+notificationSchema.virtual('read').get(function() {
+  return Boolean(this.readAt);
+});
+
+notificationSchema.index({ walletAddress: 1, createdAt: -1 });
+notificationSchema.index({ walletAddress: 1, readAt: 1, createdAt: -1 });
+notificationSchema.index({ category: 1, severity: 1, createdAt: -1 });
+
+notificationSchema.pre('validate', function(next) {
+  if (!this.notificationId) {
+    this.notificationId = `notif_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  if (this.walletAddress) {
+    this.walletAddress = this.walletAddress.toLowerCase();
+  }
+
+  next();
+});
+
+module.exports = mongoose.model('Notification', notificationSchema);

--- a/backend/src/models/NotificationPreference.js
+++ b/backend/src/models/NotificationPreference.js
@@ -1,0 +1,40 @@
+const mongoose = require('mongoose');
+
+const notificationPreferenceSchema = new mongoose.Schema({
+  walletAddress: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  preferences: {
+    portfolioMilestones: { type: Boolean, default: true },
+    transactionStatus: { type: Boolean, default: true },
+    priceAlerts: { type: Boolean, default: true },
+    liquidationWarnings: { type: Boolean, default: true },
+    governanceUpdates: { type: Boolean, default: true },
+    lowBalanceAlerts: { type: Boolean, default: true },
+    marketExpired: { type: Boolean, default: true },
+    dailyDigest: { type: Boolean, default: true },
+    treasuryAlerts: { type: Boolean, default: true },
+    riskAlerts: { type: Boolean, default: true },
+    yieldOpportunityAlerts: { type: Boolean, default: true }
+  }
+}, {
+  timestamps: true,
+  collection: 'notification_preferences'
+});
+
+notificationPreferenceSchema.pre('validate', function(next) {
+  if (this.walletAddress) {
+    this.walletAddress = this.walletAddress.toLowerCase();
+  }
+
+  if (this.preferences) {
+    this.preferences.liquidationWarnings = true;
+  }
+
+  next();
+});
+
+module.exports = mongoose.model('NotificationPreference', notificationPreferenceSchema);

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -19,6 +19,8 @@ const StateSnapshot = require('./StateSnapshot');
 const IndexerHealth = require('./IndexerHealth');
 const ChainReorg = require('./ChainReorg');
 const EmergencyEvent = require('./EmergencyEvent');
+const Notification = require('./Notification');
+const NotificationPreference = require('./NotificationPreference');
 
 module.exports = {
   Market,
@@ -41,5 +43,7 @@ module.exports = {
   StateSnapshot,
   IndexerHealth,
   ChainReorg,
-  EmergencyEvent
+  EmergencyEvent,
+  Notification,
+  NotificationPreference
 };

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const { asyncHandler } = require('../middleware/errorHandler');
+const { authenticateToken } = require('../middleware/auth');
+const NotificationController = require('../controllers/notificationController');
+
+router.use(authenticateToken);
+
+router.get('/preferences/:walletAddress', asyncHandler(NotificationController.getPreferences));
+router.post('/preferences/:walletAddress', asyncHandler(NotificationController.savePreferences));
+
+router.get('/alerts/:walletAddress', asyncHandler(NotificationController.getAlerts));
+router.get('/unread-count/:walletAddress', asyncHandler(NotificationController.getUnreadCount));
+router.put('/alerts/read-all', asyncHandler(NotificationController.markAllAlertsAsRead));
+router.put('/alerts/:alertId/read', asyncHandler(NotificationController.markAlertAsRead));
+router.delete('/alerts/:alertId', asyncHandler(NotificationController.deleteAlert));
+router.delete('/alerts', asyncHandler(NotificationController.clearAlerts));
+
+router.post('/send/transaction-status', asyncHandler(NotificationController.sendTransactionStatusAlert));
+router.post('/send/portfolio-milestone', asyncHandler(NotificationController.sendPortfolioMilestoneAlert));
+router.post('/send/liquidation-warning', asyncHandler(NotificationController.sendLiquidationWarning));
+router.post('/send/treasury-alert', asyncHandler(NotificationController.sendTreasuryAlert));
+router.post('/send/risk-alert', asyncHandler(NotificationController.sendRiskAlert));
+router.post('/send/yield-opportunity', asyncHandler(NotificationController.sendYieldOpportunity));
+router.post('/log-failure', asyncHandler(NotificationController.logAlertFailure));
+
+module.exports = router;

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -1,0 +1,326 @@
+const mongoose = require('mongoose');
+const logger = require('../config/logger');
+const pushNotificationService = require('./pushNotificationService');
+const websocketHandler = require('./websocketHandler');
+const Notification = require('../models/Notification');
+const NotificationPreference = require('../models/NotificationPreference');
+
+const DEFAULT_PREFERENCES = Object.freeze({
+  portfolioMilestones: true,
+  transactionStatus: true,
+  priceAlerts: true,
+  liquidationWarnings: true,
+  governanceUpdates: true,
+  lowBalanceAlerts: true,
+  marketExpired: true,
+  dailyDigest: true,
+  treasuryAlerts: true,
+  riskAlerts: true,
+  yieldOpportunityAlerts: true
+});
+
+const TYPE_TO_PREFERENCE = Object.freeze({
+  transaction_status: 'transactionStatus',
+  treasury_alert: 'treasuryAlerts',
+  risk_alert: 'riskAlerts',
+  yield_opportunity: 'yieldOpportunityAlerts',
+  portfolio_milestone: 'portfolioMilestones',
+  liquidation_warning: 'liquidationWarnings',
+  market_expired: 'marketExpired',
+  governance_update: 'governanceUpdates'
+});
+
+const TYPE_TO_CATEGORY = Object.freeze({
+  transaction_status: 'transaction',
+  treasury_alert: 'treasury',
+  risk_alert: 'risk',
+  yield_opportunity: 'yield',
+  portfolio_milestone: 'portfolio',
+  liquidation_warning: 'portfolio',
+  market_expired: 'market',
+  governance_update: 'governance',
+  system: 'system'
+});
+
+class NotificationService {
+  constructor() {
+    this.memoryPreferences = new Map();
+    this.memoryNotifications = new Map();
+  }
+
+  hasDatabase() {
+    return mongoose.connection.readyState === 1;
+  }
+
+  normalizeWallet(walletAddress) {
+    if (!walletAddress || typeof walletAddress !== 'string') {
+      throw new Error('walletAddress is required');
+    }
+    return walletAddress.toLowerCase();
+  }
+
+  sanitizePreferences(preferences = {}) {
+    const sanitized = { ...DEFAULT_PREFERENCES };
+    for (const key of Object.keys(DEFAULT_PREFERENCES)) {
+      if (typeof preferences[key] === 'boolean') {
+        sanitized[key] = preferences[key];
+      }
+    }
+    sanitized.liquidationWarnings = true;
+    return sanitized;
+  }
+
+  async getPreferences(walletAddress) {
+    const wallet = this.normalizeWallet(walletAddress);
+
+    if (!this.hasDatabase()) {
+      return this.memoryPreferences.get(wallet) || { ...DEFAULT_PREFERENCES };
+    }
+
+    const stored = await NotificationPreference.findOne({ walletAddress: wallet }).lean();
+    return this.sanitizePreferences(stored?.preferences);
+  }
+
+  async savePreferences(walletAddress, preferences) {
+    const wallet = this.normalizeWallet(walletAddress);
+    const sanitized = this.sanitizePreferences(preferences);
+
+    if (!this.hasDatabase()) {
+      this.memoryPreferences.set(wallet, sanitized);
+      return sanitized;
+    }
+
+    await NotificationPreference.findOneAndUpdate(
+      { walletAddress: wallet },
+      { $set: { preferences: sanitized } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    return sanitized;
+  }
+
+  shouldDeliver(type, preferences) {
+    const preferenceKey = TYPE_TO_PREFERENCE[type];
+    if (!preferenceKey) return true;
+    if (type === 'liquidation_warning') return true;
+    return preferences[preferenceKey] !== false;
+  }
+
+  serialize(notification) {
+    const doc = typeof notification.toObject === 'function'
+      ? notification.toObject({ virtuals: true })
+      : notification;
+
+    return {
+      id: doc.notificationId,
+      notificationId: doc.notificationId,
+      type: doc.type,
+      category: doc.category,
+      severity: doc.severity,
+      title: doc.title,
+      message: doc.message,
+      timestamp: (doc.createdAt || new Date()).toISOString?.() || doc.createdAt,
+      read: Boolean(doc.readAt),
+      readAt: doc.readAt || null,
+      status: doc.status,
+      metadata: doc.metadata || {},
+      delivery: doc.delivery || {}
+    };
+  }
+
+  async createNotification({
+    walletAddress,
+    type,
+    title,
+    message,
+    severity = 'info',
+    metadata = {},
+    force = false
+  }) {
+    const wallet = this.normalizeWallet(walletAddress);
+    const category = TYPE_TO_CATEGORY[type] || 'system';
+    const preferences = await this.getPreferences(wallet);
+    const deliver = force || this.shouldDeliver(type, preferences);
+    const notificationId = `notif_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    const base = {
+      notificationId,
+      walletAddress: wallet,
+      type,
+      category,
+      severity,
+      title,
+      message,
+      status: deliver ? 'delivered' : 'suppressed',
+      metadata,
+      delivery: {
+        inApp: deliver,
+        pushAttempted: false,
+        pushDelivered: false,
+        failureReason: deliver ? null : 'user_disabled_preference'
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      readAt: null
+    };
+
+    let saved = base;
+    if (this.hasDatabase()) {
+      saved = await Notification.create(base);
+    } else {
+      const list = this.memoryNotifications.get(wallet) || [];
+      list.unshift(base);
+      this.memoryNotifications.set(wallet, list);
+    }
+
+    const serialized = this.serialize(saved);
+
+    if (deliver) {
+      websocketHandler.sendUserNotification(wallet, serialized);
+      try {
+        base.delivery.pushAttempted = true;
+        await pushNotificationService.sendToWallet(wallet, {
+          title,
+          body: message,
+          tag: type,
+          data: { notificationId, type, category, severity, ...metadata }
+        });
+        base.delivery.pushDelivered = true;
+      } catch (error) {
+        base.delivery.failureReason = error.message;
+        logger.warn('Push notification delivery failed', { walletAddress: wallet, type, error: error.message });
+      }
+    }
+
+    return {
+      success: deliver,
+      deliveryMethod: deliver ? 'in_app' : 'suppressed',
+      timestamp: serialized.timestamp,
+      notification: serialized,
+      error: deliver ? undefined : 'User disabled this notification type'
+    };
+  }
+
+  async listNotifications(walletAddress, { limit = 50, page = 1, unreadOnly = false, category } = {}) {
+    const wallet = this.normalizeWallet(walletAddress);
+    const safeLimit = Math.min(Math.max(parseInt(limit, 10) || 50, 1), 100);
+    const safePage = Math.max(parseInt(page, 10) || 1, 1);
+
+    if (!this.hasDatabase()) {
+      let list = this.memoryNotifications.get(wallet) || [];
+      if (unreadOnly) list = list.filter((item) => item.status === 'delivered' && !item.readAt);
+      if (category) list = list.filter((item) => item.category === category);
+      const start = (safePage - 1) * safeLimit;
+      return {
+        notifications: list.slice(start, start + safeLimit).map((item) => this.serialize(item)),
+        pagination: { page: safePage, limit: safeLimit, total: list.length, pages: Math.ceil(list.length / safeLimit) }
+      };
+    }
+
+    const filter = { walletAddress: wallet };
+    if (unreadOnly) filter.readAt = null;
+    if (category) filter.category = category;
+
+    const [notifications, total] = await Promise.all([
+      Notification.find(filter)
+        .sort({ createdAt: -1 })
+        .skip((safePage - 1) * safeLimit)
+        .limit(safeLimit),
+      Notification.countDocuments(filter)
+    ]);
+
+    return {
+      notifications: notifications.map((item) => this.serialize(item)),
+      pagination: { page: safePage, limit: safeLimit, total, pages: Math.ceil(total / safeLimit) }
+    };
+  }
+
+  async unreadCount(walletAddress) {
+    const wallet = this.normalizeWallet(walletAddress);
+
+    if (!this.hasDatabase()) {
+      return (this.memoryNotifications.get(wallet) || [])
+        .filter((item) => item.status === 'delivered' && !item.readAt).length;
+    }
+
+    return Notification.countDocuments({ walletAddress: wallet, status: 'delivered', readAt: null });
+  }
+
+  async markRead(walletAddress, notificationId) {
+    const wallet = this.normalizeWallet(walletAddress);
+    const readAt = new Date();
+
+    if (!this.hasDatabase()) {
+      const list = this.memoryNotifications.get(wallet) || [];
+      const notification = list.find((item) => item.notificationId === notificationId);
+      if (!notification) return null;
+      notification.readAt = readAt;
+      return this.serialize(notification);
+    }
+
+    const notification = await Notification.findOneAndUpdate(
+      { walletAddress: wallet, notificationId },
+      { $set: { readAt } },
+      { new: true }
+    );
+    return notification ? this.serialize(notification) : null;
+  }
+
+  async markAllRead(walletAddress) {
+    const wallet = this.normalizeWallet(walletAddress);
+    const readAt = new Date();
+
+    if (!this.hasDatabase()) {
+      const list = this.memoryNotifications.get(wallet) || [];
+      let modified = 0;
+      list.forEach((item) => {
+        if (item.status === 'delivered' && !item.readAt) {
+          item.readAt = readAt;
+          modified += 1;
+        }
+      });
+      return modified;
+    }
+
+    const result = await Notification.updateMany(
+      { walletAddress: wallet, status: 'delivered', readAt: null },
+      { $set: { readAt } }
+    );
+    return result.modifiedCount || 0;
+  }
+
+  async deleteNotification(walletAddress, notificationId) {
+    const wallet = this.normalizeWallet(walletAddress);
+
+    if (!this.hasDatabase()) {
+      const list = this.memoryNotifications.get(wallet) || [];
+      const next = list.filter((item) => item.notificationId !== notificationId);
+      this.memoryNotifications.set(wallet, next);
+      return next.length !== list.length;
+    }
+
+    const result = await Notification.deleteOne({ walletAddress: wallet, notificationId });
+    return result.deletedCount === 1;
+  }
+
+  async clearNotifications(walletAddress) {
+    const wallet = this.normalizeWallet(walletAddress);
+
+    if (!this.hasDatabase()) {
+      const count = (this.memoryNotifications.get(wallet) || []).length;
+      this.memoryNotifications.set(wallet, []);
+      return count;
+    }
+
+    const result = await Notification.deleteMany({ walletAddress: wallet });
+    return result.deletedCount || 0;
+  }
+
+  resetMemoryStore() {
+    this.memoryPreferences.clear();
+    this.memoryNotifications.clear();
+  }
+}
+
+module.exports = new NotificationService();
+module.exports.DEFAULT_PREFERENCES = DEFAULT_PREFERENCES;
+module.exports.TYPE_TO_PREFERENCE = TYPE_TO_PREFERENCE;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import LiquidityRebalancing from "./pages/LiquidityRebalancing";
 import OracleConsensus from "./pages/OracleConsensus";
 import GovernanceTimelock from "./pages/GovernanceTimelock";
 import NotificationPreferences from "./pages/NotificationPreferences";
+import Notifications from "./pages/Notifications";
 import PortfolioAnalytics from "./pages/PortfolioAnalytics";
 import AuditLogs from "./pages/AuditLogs";
 import { OfflineBanner } from "@/components/OfflineBanner";
@@ -128,6 +129,7 @@ const App = () => (
                 <Route path="/oracle/consensus" element={<OracleConsensus />} />
                 <Route path="/governance/timelock" element={<GovernanceTimelock />} />
                 <Route path="/notifications/preferences" element={<NotificationPreferences />} />
+                <Route path="/notifications" element={<Notifications />} />
                 <Route path="/portfolio/analytics" element={<PortfolioAnalytics />} />
                 <Route path="/audit" element={<AuditLogs />} />
                 <Route path="*" element={<NotFound />} />

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertTriangle, Bell, CheckCheck, Settings, Sparkles, WalletCards } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useWallet } from '@/contexts/WalletContext';
+import { notificationService, NotificationAlert } from '@/services/notificationService';
+
+const iconByCategory = {
+  transaction: WalletCards,
+  treasury: WalletCards,
+  risk: AlertTriangle,
+  yield: Sparkles,
+  portfolio: WalletCards,
+  market: Bell,
+  governance: Bell,
+  system: Bell,
+};
+
+export function NotificationBell() {
+  const { isConnected, publicKey } = useWallet();
+  const [alerts, setAlerts] = useState<NotificationAlert[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [open, setOpen] = useState(false);
+
+  const recentAlerts = useMemo(() => alerts.slice(0, 5), [alerts]);
+
+  const refresh = async () => {
+    if (!isConnected || !publicKey) {
+      setAlerts([]);
+      setUnreadCount(0);
+      return;
+    }
+
+    const [history, count] = await Promise.all([
+      notificationService.getNotificationHistory(publicKey, { limit: 5 }),
+      notificationService.getUnreadAlertCount(publicKey),
+    ]);
+    setAlerts(history);
+    setUnreadCount(count);
+  };
+
+  useEffect(() => {
+    refresh();
+    if (!isConnected || !publicKey) return undefined;
+    const interval = window.setInterval(refresh, 30000);
+    return () => window.clearInterval(interval);
+  }, [isConnected, publicKey]);
+
+  const markAllRead = async () => {
+    if (!publicKey) return;
+    await notificationService.markAllAlertsAsRead(publicKey);
+    await refresh();
+  };
+
+  if (!isConnected) return null;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative h-9 w-9 rounded-full text-neutral-300 hover:text-white">
+          <Bell className="h-4 w-4" />
+          {unreadCount > 0 && (
+            <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-orange-500 px-1 text-[10px] font-semibold text-white">
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 border-white/10 bg-black/90 text-white backdrop-blur-xl">
+        <div className="flex items-center justify-between px-2 py-1">
+          <DropdownMenuLabel className="px-0">Notifications</DropdownMenuLabel>
+          <div className="flex items-center gap-1">
+            <Button variant="ghost" size="icon" className="h-8 w-8 text-neutral-300" onClick={markAllRead} disabled={unreadCount === 0}>
+              <CheckCheck className="h-4 w-4" />
+            </Button>
+            <Button variant="ghost" size="icon" className="h-8 w-8 text-neutral-300" asChild>
+              <Link to="/notifications/preferences" onClick={() => setOpen(false)}>
+                <Settings className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+        <DropdownMenuSeparator className="bg-white/10" />
+        <ScrollArea className="h-80">
+          {recentAlerts.length === 0 ? (
+            <div className="px-3 py-8 text-center text-sm text-neutral-400">No notifications yet</div>
+          ) : (
+            recentAlerts.map((alert) => {
+              const Icon = iconByCategory[alert.category as keyof typeof iconByCategory] || Bell;
+              return (
+                <DropdownMenuItem key={alert.id} className="items-start gap-3 p-3 focus:bg-white/10" asChild>
+                  <Link to="/notifications" onClick={() => setOpen(false)}>
+                    <Icon className={`mt-0.5 h-4 w-4 ${alert.severity === 'critical' ? 'text-red-400' : alert.severity === 'warning' ? 'text-orange-400' : 'text-teal-300'}`} />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">{alert.title}</span>
+                      <span className="line-clamp-2 text-xs text-neutral-400">{alert.message}</span>
+                    </span>
+                    {!alert.read && <span className="mt-1 h-2 w-2 rounded-full bg-orange-500" />}
+                  </Link>
+                </DropdownMenuItem>
+              );
+            })
+          )}
+        </ScrollArea>
+        <DropdownMenuSeparator className="bg-white/10" />
+        <DropdownMenuItem asChild className="justify-center focus:bg-white/10">
+          <Link to="/notifications" onClick={() => setOpen(false)}>View notification center</Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -4,6 +4,7 @@ import { Menu, X, Shield } from 'lucide-react';
 import { WalletSelector } from '@/components/WalletSelector';
 import { WalletBalance } from '@/components/wallet/WalletBalance';
 import { CompactWalletBalance } from '@/components/wallet/CompactWalletBalance';
+import { NotificationBell } from '@/components/NotificationBell';
 import { useWallet } from '@/contexts/WalletContext';
 import { useI18n } from '@/i18n';
 
@@ -87,6 +88,7 @@ export function Navbar() {
                   <WalletBalance />
                 </div>
                 <CompactWalletBalance />
+                <NotificationBell />
               </>
             )}
             <WalletSelector />

--- a/frontend/src/pages/NotificationPreferences.tsx
+++ b/frontend/src/pages/NotificationPreferences.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import {
   Bell,
   AlertCircle,
-  CheckCircle2,
   Loader2,
   Save,
   RotateCcw,
@@ -10,26 +9,17 @@ import {
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { MagicCard } from '@/components/magicui/magic-card';
+import { Switch } from '@/components/ui/switch';
 import { useWallet } from '@/contexts/WalletContext';
-import { notificationService } from '@/services/notificationService';
+import { notificationService, NotificationPreferences as NotificationPreferencesModel } from '@/services/notificationService';
 import { toast } from 'sonner';
 
-interface NotificationPreferences {
-  portfolioMilestones: boolean;
-  transactionStatus: boolean;
-  priceAlerts: boolean;
-  liquidationWarnings: boolean;
-  governanceUpdates: boolean;
-  lowBalanceAlerts: boolean;
-  marketExpired: boolean;
-  dailyDigest: boolean;
-}
-
 interface PreferenceCategory {
-  id: keyof NotificationPreferences;
+  id: keyof NotificationPreferencesModel;
   label: string;
   description: string;
-  category: 'portfolio' | 'transaction' | 'market' | 'governance';
+  category: 'portfolio' | 'transaction' | 'market' | 'governance' | 'protocol';
+  locked?: boolean;
 }
 
 const PREFERENCE_CATEGORIES: PreferenceCategory[] = [
@@ -56,6 +46,7 @@ const PREFERENCE_CATEGORIES: PreferenceCategory[] = [
     label: 'Liquidation Warnings',
     description: 'Critical alerts for positions at risk of liquidation',
     category: 'portfolio',
+    locked: true,
   },
   {
     id: 'governanceUpdates',
@@ -81,12 +72,30 @@ const PREFERENCE_CATEGORIES: PreferenceCategory[] = [
     description: 'Daily summary of portfolio activity and market updates',
     category: 'portfolio',
   },
+  {
+    id: 'treasuryAlerts',
+    label: 'Treasury Alerts',
+    description: 'Protocol treasury inflow, outflow, and threshold warnings',
+    category: 'protocol',
+  },
+  {
+    id: 'riskAlerts',
+    label: 'Risk Alerts',
+    description: 'Risk score, concentration, and volatility threshold alerts',
+    category: 'protocol',
+  },
+  {
+    id: 'yieldOpportunityAlerts',
+    label: 'Yield Opportunity Alerts',
+    description: 'Notifications when high quality yield opportunities appear',
+    category: 'protocol',
+  },
 ];
 
 export default function NotificationPreferences() {
   const { publicKey, isConnected } = useWallet();
-  const [preferences, setPreferences] = useState<NotificationPreferences | null>(null);
-  const [originalPreferences, setOriginalPreferences] = useState<NotificationPreferences | null>(null);
+  const [preferences, setPreferences] = useState<NotificationPreferencesModel | null>(null);
+  const [originalPreferences, setOriginalPreferences] = useState<NotificationPreferencesModel | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -115,8 +124,9 @@ export default function NotificationPreferences() {
     fetchPreferences();
   }, [publicKey, isConnected]);
 
-  const handleToggle = (key: keyof NotificationPreferences) => {
+  const handleToggle = (key: keyof NotificationPreferencesModel) => {
     if (!preferences) return;
+    if (key === 'liquidationWarnings') return;
     setPreferences({
       ...preferences,
       [key]: !preferences[key],
@@ -215,6 +225,7 @@ export default function NotificationPreferences() {
   const transactionPrefs = PREFERENCE_CATEGORIES.filter((cat) => cat.category === 'transaction');
   const marketPrefs = PREFERENCE_CATEGORIES.filter((cat) => cat.category === 'market');
   const governancePrefs = PREFERENCE_CATEGORIES.filter((cat) => cat.category === 'governance');
+  const protocolPrefs = PREFERENCE_CATEGORIES.filter((cat) => cat.category === 'protocol');
 
   return (
     <Layout>
@@ -261,6 +272,14 @@ export default function NotificationPreferences() {
           onToggle={handleToggle}
         />
 
+        <PreferenceSection
+          title="Protocol Alerts"
+          description="Monitor treasury, risk, and yield opportunity events"
+          preferences={protocolPrefs}
+          currentPrefs={preferences}
+          onToggle={handleToggle}
+        />
+
         <div className="mt-8 flex gap-4 justify-end">
           <Button
             onClick={handleReset}
@@ -291,8 +310,7 @@ export default function NotificationPreferences() {
               <p className="font-medium mb-1">About Your Preferences</p>
               <p>
                 Your notification settings are saved securely. You can change them anytime.
-                Some critical alerts (like liquidation warnings) cannot be disabled for your
-                protection.
+                Critical liquidation warnings are always kept on for account protection.
               </p>
             </div>
           </div>
@@ -306,8 +324,8 @@ interface PreferenceSectionProps {
   title: string;
   description: string;
   preferences: PreferenceCategory[];
-  currentPrefs: NotificationPreferences;
-  onToggle: (key: keyof NotificationPreferences) => void;
+  currentPrefs: NotificationPreferencesModel;
+  onToggle: (key: keyof NotificationPreferencesModel) => void;
 }
 
 function PreferenceSection({
@@ -338,28 +356,28 @@ function PreferenceSection({
 interface PreferenceToggleProps {
   preference: PreferenceCategory;
   enabled: boolean;
-  onToggle: (key: keyof NotificationPreferences) => void;
+  onToggle: (key: keyof NotificationPreferencesModel) => void;
 }
 
 function PreferenceToggle({ preference, enabled, onToggle }: PreferenceToggleProps) {
   return (
     <button
       onClick={() => onToggle(preference.id)}
+      disabled={preference.locked}
       className="w-full flex items-start gap-4 p-3 rounded-lg border border-border hover:bg-muted/50 transition-colors text-left"
     >
       <div className="flex-1 min-w-0">
-        <p className="font-medium text-sm">{preference.label}</p>
+        <div className="flex items-center gap-2">
+          <p className="font-medium text-sm">{preference.label}</p>
+          {preference.locked && (
+            <span className="rounded-full border border-orange-400/30 px-2 py-0.5 text-[11px] text-orange-300">
+              Required
+            </span>
+          )}
+        </div>
         <p className="text-xs text-muted-foreground mt-1">{preference.description}</p>
       </div>
-      <div className="flex-shrink-0 mt-1">
-        {enabled ? (
-          <div className="w-6 h-6 rounded-full bg-primary flex items-center justify-center">
-            <CheckCircle2 className="w-4 h-4 text-primary-foreground" />
-          </div>
-        ) : (
-          <div className="w-6 h-6 rounded-full border-2 border-muted-foreground" />
-        )}
-      </div>
+      <Switch checked={enabled} disabled={preference.locked} className="mt-1" />
     </button>
   );
 }

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Bell, CheckCheck, Loader2, Trash2 } from 'lucide-react';
+import { Layout } from '@/components/layout/Layout';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { MagicCard } from '@/components/magicui/magic-card';
+import { useWallet } from '@/contexts/WalletContext';
+import { notificationService, NotificationAlert } from '@/services/notificationService';
+import { toast } from 'sonner';
+
+const categoryLabels: Record<string, string> = {
+  transaction: 'Transaction',
+  treasury: 'Treasury',
+  risk: 'Risk',
+  yield: 'Yield',
+  portfolio: 'Portfolio',
+  market: 'Market',
+  governance: 'Governance',
+  system: 'System',
+};
+
+export default function Notifications() {
+  const { publicKey, isConnected } = useWallet();
+  const [alerts, setAlerts] = useState<NotificationAlert[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const loadNotifications = async () => {
+    if (!publicKey) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const [history, count] = await Promise.all([
+      notificationService.getNotificationHistory(publicKey, { limit: 100 }),
+      notificationService.getUnreadAlertCount(publicKey),
+    ]);
+    setAlerts(history);
+    setUnreadCount(count);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadNotifications();
+  }, [publicKey]);
+
+  const markAllRead = async () => {
+    if (!publicKey) return;
+    await notificationService.markAllAlertsAsRead(publicKey);
+    toast.success('All notifications marked as read');
+    await loadNotifications();
+  };
+
+  const clearAll = async () => {
+    if (!publicKey) return;
+    await notificationService.clearAllAlerts(publicKey);
+    toast.success('Notification history cleared');
+    await loadNotifications();
+  };
+
+  if (!isConnected) {
+    return (
+      <Layout>
+        <div className="container mx-auto px-4 py-12">
+          <h1 className="text-3xl font-bold">Notification Center</h1>
+          <p className="mt-3 text-muted-foreground">Connect your wallet to view notification history.</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="container mx-auto max-w-4xl px-4 py-12">
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <Bell className="h-8 w-8 text-primary" />
+            <div>
+              <h1 className="text-3xl font-bold">Notification Center</h1>
+              <p className="text-muted-foreground">Protocol alerts, trade updates, and yield opportunities in one place.</p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={markAllRead} disabled={unreadCount === 0}>
+              <CheckCheck className="mr-2 h-4 w-4" />
+              Mark read
+            </Button>
+            <Button variant="outline" onClick={clearAll} disabled={alerts.length === 0}>
+              <Trash2 className="mr-2 h-4 w-4" />
+              Clear
+            </Button>
+          </div>
+        </div>
+
+        <MagicCard className="glass-card p-6" gradientColor="#262626">
+          {loading ? (
+            <div className="flex min-h-64 items-center justify-center">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : alerts.length === 0 ? (
+            <div className="flex min-h-64 flex-col items-center justify-center text-center">
+              <Bell className="mb-4 h-10 w-10 text-muted-foreground" />
+              <p className="font-medium">No notifications yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">Important protocol and account events will appear here.</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              {alerts.map((alert) => (
+                <div key={alert.id} className="flex gap-4 py-4">
+                  <div className={`mt-1 flex h-9 w-9 items-center justify-center rounded-full ${alert.severity === 'critical' ? 'bg-red-500/15 text-red-400' : alert.severity === 'warning' ? 'bg-orange-500/15 text-orange-400' : 'bg-teal-500/15 text-teal-300'}`}>
+                    <AlertTriangle className="h-4 w-4" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="font-semibold">{alert.title}</h2>
+                      <Badge variant={alert.read ? 'outline' : 'default'}>{alert.read ? 'Read' : 'Unread'}</Badge>
+                      <Badge variant="secondary">{categoryLabels[alert.category] || alert.category}</Badge>
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">{alert.message}</p>
+                    <p className="mt-2 text-xs text-muted-foreground">{new Date(alert.timestamp).toLocaleString()}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </MagicCard>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '@/lib/api-client';
 
-interface NotificationPreferences {
+export interface NotificationPreferences {
   portfolioMilestones: boolean;
   transactionStatus: boolean;
   priceAlerts: boolean;
@@ -9,15 +9,23 @@ interface NotificationPreferences {
   lowBalanceAlerts: boolean;
   marketExpired: boolean;
   dailyDigest: boolean;
+  treasuryAlerts: boolean;
+  riskAlerts: boolean;
+  yieldOpportunityAlerts: boolean;
 }
 
-interface NotificationAlert {
+export interface NotificationAlert {
   id: string;
   type: string;
+  category: string;
+  severity: 'info' | 'success' | 'warning' | 'critical';
   title: string;
   message: string;
   timestamp: string;
   read: boolean;
+  readAt?: string | null;
+  status?: string;
+  metadata?: Record<string, any>;
 }
 
 interface AlertDeliveryResult {
@@ -36,6 +44,9 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
   lowBalanceAlerts: true,
   marketExpired: true,
   dailyDigest: true,
+  treasuryAlerts: true,
+  riskAlerts: true,
+  yieldOpportunityAlerts: true,
 };
 
 export const notificationService = {
@@ -82,6 +93,31 @@ export const notificationService = {
       return [];
     } catch (error) {
       console.error('Failed to fetch alerts:', error);
+      return [];
+    }
+  },
+
+  async getNotificationHistory(
+    walletAddress: string,
+    options: { limit?: number; page?: number; unreadOnly?: boolean; category?: string } = {}
+  ): Promise<NotificationAlert[]> {
+    apiClient.setAuthToken(walletAddress);
+    const params = new URLSearchParams();
+    params.set('limit', String(options.limit || 50));
+    params.set('page', String(options.page || 1));
+    if (options.unreadOnly) params.set('unreadOnly', 'true');
+    if (options.category) params.set('category', options.category);
+
+    try {
+      const response = await apiClient.get<NotificationAlert[]>(
+        `/notifications/alerts/${walletAddress}?${params.toString()}`
+      );
+      if (response.success && response.data) {
+        return response.data;
+      }
+      return [];
+    } catch (error) {
+      console.error('Failed to fetch notification history:', error);
       return [];
     }
   },
@@ -216,6 +252,69 @@ export const notificationService = {
         error: error instanceof Error ? error.message : 'Unknown error',
       };
     }
+  },
+
+  async sendTreasuryAlert(
+    walletAddress: string,
+    data: {
+      eventType: string;
+      amount?: number;
+      asset?: string;
+      threshold?: number;
+      message?: string;
+    }
+  ): Promise<AlertDeliveryResult> {
+    apiClient.setAuthToken(walletAddress);
+    const response = await apiClient.post<AlertDeliveryResult>(
+      `/notifications/send/treasury-alert`,
+      { walletAddress, ...data }
+    );
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Failed to send treasury alert');
+    }
+    return response.data;
+  },
+
+  async sendRiskAlert(
+    walletAddress: string,
+    data: {
+      riskType: string;
+      score?: number;
+      severity?: 'info' | 'warning' | 'critical';
+      message?: string;
+      metadata?: Record<string, any>;
+    }
+  ): Promise<AlertDeliveryResult> {
+    apiClient.setAuthToken(walletAddress);
+    const response = await apiClient.post<AlertDeliveryResult>(
+      `/notifications/send/risk-alert`,
+      { walletAddress, ...data }
+    );
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Failed to send risk alert');
+    }
+    return response.data;
+  },
+
+  async sendYieldOpportunityAlert(
+    walletAddress: string,
+    data: {
+      marketId: string;
+      question?: string;
+      apy: number;
+      riskScore?: number;
+      message?: string;
+    }
+  ): Promise<AlertDeliveryResult> {
+    apiClient.setAuthToken(walletAddress);
+    const response = await apiClient.post<AlertDeliveryResult>(
+      `/notifications/send/yield-opportunity`,
+      { walletAddress, ...data }
+    );
+    if (!response.success || !response.data) {
+      throw new Error(response.message || 'Failed to send yield opportunity alert');
+    }
+    return response.data;
   },
 
   async logAlertFailure(

--- a/frontend/src/test/notification-preferences.test.ts
+++ b/frontend/src/test/notification-preferences.test.ts
@@ -9,6 +9,9 @@ interface NotificationPreferences {
   lowBalanceAlerts: boolean;
   marketExpired: boolean;
   dailyDigest: boolean;
+  treasuryAlerts: boolean;
+  riskAlerts: boolean;
+  yieldOpportunityAlerts: boolean;
 }
 
 const DEFAULT_PREFERENCES: NotificationPreferences = {
@@ -20,6 +23,9 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
   lowBalanceAlerts: true,
   marketExpired: true,
   dailyDigest: true,
+  treasuryAlerts: true,
+  riskAlerts: true,
+  yieldOpportunityAlerts: true,
 };
 
 describe('Notification Preferences', () => {
@@ -44,6 +50,9 @@ describe('Notification Preferences', () => {
         'lowBalanceAlerts',
         'marketExpired',
         'dailyDigest',
+        'treasuryAlerts',
+        'riskAlerts',
+        'yieldOpportunityAlerts',
       ];
 
       requiredKeys.forEach((key) => {
@@ -226,11 +235,11 @@ describe('Notification Preferences', () => {
 
     it('should provide accurate count of enabled preferences', () => {
       const enabledCount = Object.values(preferences).filter((v) => v === true).length;
-      expect(enabledCount).toBe(8);
+      expect(enabledCount).toBe(11);
 
       preferences.portfolioMilestones = false;
       const newEnabledCount = Object.values(preferences).filter((v) => v === true).length;
-      expect(newEnabledCount).toBe(7);
+      expect(newEnabledCount).toBe(10);
     });
 
     it('should validate preference UI state matches actual state', () => {
@@ -294,6 +303,7 @@ describe('Notification Preferences', () => {
         transaction: ['transactionStatus'],
         market: ['priceAlerts', 'marketExpired'],
         governance: ['governanceUpdates'],
+        protocol: ['treasuryAlerts', 'riskAlerts', 'yieldOpportunityAlerts'],
       };
 
       Object.entries(categories).forEach(([category, keys]) => {


### PR DESCRIPTION
## Summary
- add durable in-app notification history with unread badge counts and read/delete actions
- add configurable notification preferences for transaction, treasury, risk, yield, portfolio, market, and governance alerts
- wire a navbar notification bell and full notification center page

## Testing
- npx jest --runTestsByPath __tests__\services\notificationService.test.js --runInBand
- npm test -- src\test\notification-preferences.test.ts
- npm run build

Closes #197