### PR TITLE
feat: add oracle data provenance layer

### DIFF
--- a/backend/__tests__/integration/oracleProvenanceApi.test.js
+++ b/backend/__tests__/integration/oracleProvenanceApi.test.js
@@ -1,0 +1,280 @@
+/**
+ * Integration tests for the Oracle Data Provenance API (#241).
+ *
+ *   GET /api/markets/:id/resolution/provenance
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ---------------------------------------------------------------------------
+// Mock models BEFORE requiring the routes.
+// ---------------------------------------------------------------------------
+
+const mockMarketFindOne = jest.fn();
+const MockMarket = jest.fn(function (data) {
+  Object.assign(this, data);
+});
+MockMarket.findOne = mockMarketFindOne;
+
+const mockProvenanceFind = jest.fn();
+const MockOracleProvenanceRecord = jest.fn(function (data) {
+  Object.assign(this, data);
+});
+MockOracleProvenanceRecord.find = mockProvenanceFind;
+
+const MockResolutionEvent = jest.fn();
+MockResolutionEvent.find = jest.fn();
+
+jest.mock('../../src/models', () => ({
+  Market: MockMarket,
+  OracleProvenanceRecord: MockOracleProvenanceRecord,
+  ResolutionEvent: MockResolutionEvent
+}));
+
+jest.mock('../../src/services/sorobanService', () => ({
+  queryContract: jest.fn().mockResolvedValue({ result: {} }),
+  contracts: { ORACLE_RESOLVER: 'ORACLE_RESOLVER_CONTRACT' }
+}));
+
+jest.mock('../../src/config/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  oracle: jest.fn()
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  authenticateToken: (req, _res, next) => {
+    req.user = { walletAddress: 'GTEST' };
+    next();
+  },
+  optionalAuth: (_req, _res, next) => next()
+}));
+
+const marketRoutes = require('../../src/routes/markets');
+const { errorHandler, notFound } = require('../../src/middleware/errorHandler');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMarket(overrides = {}) {
+  return {
+    marketId: 'MKT-prov-1',
+    status: 'resolved',
+    resolvedOutcome: 'yes',
+    resolvedAt: new Date('2026-01-15T12:00:00Z'),
+    resolvedBy: 'oracle',
+    resolutionTransactionHash: 'stellar-tx-1',
+    resolutionFinalizationTxHash: null,
+    resolutionFinalizationTimestamp: null,
+    ...overrides
+  };
+}
+
+function makeRecord(overrides = {}) {
+  return {
+    _id: `rec-${Math.random().toString(16).slice(2)}`,
+    marketId: 'MKT-prov-1',
+    batchId: 'MKT-prov-1:batch-1',
+    provider: 'coingecko',
+    providerRequestId: 'bitcoin',
+    receivedAt: new Date('2026-01-15T11:59:59Z'),
+    normalizedOutcome: 'yes',
+    confidence: 0.95,
+    numericValue: 105000,
+    sourceValue: { outcome: 'yes', confidence: 0.95, value: 105000 },
+    responseMetadata: { source: 'coingecko', symbol: 'bitcoin' },
+    validationStatus: 'valid',
+    rejectionReason: null,
+    rejectionDetail: null,
+    stale: false,
+    freshness: null,
+    participatedInConsensus: true,
+    weightInConsensus: 0.5,
+    consensusContext: {
+      providersAccepted: ['coingecko', 'chainlink'],
+      providersRejected: { stale: ['sports-api'], outliers: [], invalid: [] },
+      finalOutcome: 'yes',
+      consensusReached: true,
+      agreementRatio: 0.82
+    },
+    contributedToResolution: true,
+    resolutionRef: {
+      resolvedOutcome: 'yes',
+      resolutionTransactionHash: 'stellar-tx-1'
+    },
+    recordedAt: new Date('2026-01-15T12:00:00Z'),
+    ...overrides
+  };
+}
+
+/** Mimic Model.find(...).sort(...).lean() */
+function findChain(value) {
+  return {
+    sort: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(value)
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('GET /api/markets/:id/resolution/provenance', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/markets', marketRoutes);
+    app.use(notFound);
+    app.use(errorHandler);
+  });
+
+  it('returns the full provenance trail for a resolved market', async () => {
+    const records = [
+      makeRecord({ provider: 'coingecko', validationStatus: 'valid', participatedInConsensus: true, contributedToResolution: true }),
+      makeRecord({ provider: 'chainlink', validationStatus: 'valid', participatedInConsensus: true, contributedToResolution: true, providerRequestId: 'BTC/USD' }),
+      makeRecord({
+        provider: 'sports-api',
+        validationStatus: 'stale',
+        stale: true,
+        rejectionReason: 'freshness_violation',
+        rejectionDetail: 'Response age 1200000ms exceeds max staleness 300000ms',
+        freshness: { ageMs: 1200000, maxAgeMs: 300000 },
+        participatedInConsensus: false,
+        contributedToResolution: false,
+        normalizedOutcome: 'no'
+      }),
+      makeRecord({
+        provider: 'news-api',
+        validationStatus: 'rejected',
+        rejectionReason: 'validation_failure',
+        rejectionDetail: 'Consensus engine rejected response: missing_source_or_outcome',
+        participatedInConsensus: false,
+        contributedToResolution: false,
+        normalizedOutcome: null
+      })
+    ];
+
+    mockMarketFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(makeMarket()) });
+    mockProvenanceFind.mockReturnValue(findChain(records));
+
+    const res = await request(app)
+      .get('/api/markets/MKT-prov-1/resolution/provenance')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    const data = res.body.data;
+
+    // Resolution summary
+    expect(data.resolution).toMatchObject({
+      status: 'resolved',
+      resolvedOutcome: 'yes',
+      resolutionTransactionHash: 'stellar-tx-1'
+    });
+
+    // Every observation is present with provider identity, timestamp and status
+    expect(data.observations).toHaveLength(4);
+    data.observations.forEach((o) => {
+      expect(o).toHaveProperty('provider');
+      expect(o).toHaveProperty('receivedAt');
+      expect(o).toHaveProperty('validationStatus');
+    });
+
+    // Rejected + stale observations remain visible with reasons
+    const stale = data.observations.find((o) => o.provider === 'sports-api');
+    expect(stale.validationStatus).toBe('stale');
+    expect(stale.stale).toBe(true);
+    expect(stale.rejectionReason).toBe('freshness_violation');
+    expect(stale.freshness).toEqual({ ageMs: 1200000, maxAgeMs: 300000 });
+
+    const rejected = data.observations.find((o) => o.provider === 'news-api');
+    expect(rejected.validationStatus).toBe('rejected');
+    expect(rejected.rejectionReason).toBe('validation_failure');
+
+    // Contributing inputs are identifiable
+    const attempt = data.attempts[0];
+    expect(attempt.contributingProviders.sort()).toEqual(['chainlink', 'coingecko']);
+    expect(attempt.staleProviders).toEqual(['sports-api']);
+    expect(attempt.rejectedProviders).toEqual([{ provider: 'news-api', reason: 'validation_failure' }]);
+
+    // Decision context is exposed
+    expect(data.decision_context).toBeTruthy();
+    expect(data.decision_context.consensusContext.finalOutcome).toBe('yes');
+    expect(data.legacy_resolution).toBe(false);
+  });
+
+  it('does not expose credentials in observation metadata', async () => {
+    const records = [
+      makeRecord({ responseMetadata: { source: 'coingecko', symbol: 'bitcoin', apiKey: '[redacted]' } })
+    ];
+    mockMarketFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(makeMarket()) });
+    mockProvenanceFind.mockReturnValue(findChain(records));
+
+    const res = await request(app)
+      .get('/api/markets/MKT-prov-1/resolution/provenance')
+      .expect(200);
+
+    expect(JSON.stringify(res.body)).not.toContain('super-secret');
+    expect(res.body.data.observations[0].responseMetadata.apiKey).toBe('[redacted]');
+  });
+
+  it('flags a resolved market with no provenance records as legacy', async () => {
+    mockMarketFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(makeMarket()) });
+    mockProvenanceFind.mockReturnValue(findChain([]));
+
+    const res = await request(app)
+      .get('/api/markets/MKT-prov-1/resolution/provenance')
+      .expect(200);
+
+    expect(res.body.data.observations).toEqual([]);
+    expect(res.body.data.attempts).toEqual([]);
+    expect(res.body.data.decision_context).toBeNull();
+    expect(res.body.data.legacy_resolution).toBe(true);
+  });
+
+  it('returns an empty, non-legacy trail for an unresolved market', async () => {
+    mockMarketFindOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue(makeMarket({ status: 'active', resolvedOutcome: null, resolvedAt: null }))
+    });
+    mockProvenanceFind.mockReturnValue(findChain([]));
+
+    const res = await request(app)
+      .get('/api/markets/MKT-prov-1/resolution/provenance')
+      .expect(200);
+
+    expect(res.body.data.legacy_resolution).toBe(false);
+    expect(res.body.data.observations).toEqual([]);
+  });
+
+  it('returns 404 for an unknown market', async () => {
+    mockMarketFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+
+    const res = await request(app)
+      .get('/api/markets/nope/resolution/provenance')
+      .expect(404);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.message).toContain('Market not found');
+  });
+
+  it('separates multiple resolution attempts by batch, oldest first', async () => {
+    const records = [
+      makeRecord({ batchId: 'b1', provider: 'coingecko', recordedAt: new Date('2026-01-15T10:00:00Z'), contributedToResolution: false }),
+      makeRecord({ batchId: 'b2', provider: 'coingecko', recordedAt: new Date('2026-01-15T12:00:00Z'), contributedToResolution: true })
+    ];
+    mockMarketFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(makeMarket()) });
+    mockProvenanceFind.mockReturnValue(findChain(records));
+
+    const res = await request(app)
+      .get('/api/markets/MKT-prov-1/resolution/provenance')
+      .expect(200);
+
+    expect(res.body.data.attempts.map((a) => a.batchId)).toEqual(['b1', 'b2']);
+    // decision_context reflects the latest attempt
+    expect(res.body.data.decision_context.batchId).toBe('b2');
+  });
+});

--- a/backend/__tests__/services/oracleProvenanceRecorder.test.js
+++ b/backend/__tests__/services/oracleProvenanceRecorder.test.js
@@ -1,0 +1,394 @@
+/**
+ * Unit tests for OracleProvenanceRecorder (#241).
+ *
+ * Covers:
+ *   - multi-provider attempt: valid / valid / stale / rejected all persisted
+ *   - stale response: persisted, marked stale, reason recorded, excluded
+ *   - invalid/malformed response: persisted, rejected, reason available, excluded
+ *   - resolution linkage: contributing observations linked, excluded stay excluded
+ *   - credentials are never persisted
+ */
+
+// ---------------------------------------------------------------------------
+// In-memory OracleProvenanceRecord mock (mirrors the Mongoose surface used).
+// ---------------------------------------------------------------------------
+
+let store = [];
+let autoId = 1;
+
+function matches(doc, filter = {}) {
+  return Object.entries(filter).every(([key, value]) => {
+    if (key === '_id') return doc._id === value;
+    return doc[key] === value;
+  });
+}
+
+const MockOracleProvenanceRecord = {
+  updateOne: jest.fn(async (filter = {}, update = {}, options = {}) => {
+    let doc = store.find((d) => matches(d, filter));
+    if (!doc && options.upsert) {
+      doc = { _id: `rec_${autoId++}` };
+      store.push(doc);
+      if (update.$setOnInsert) Object.assign(doc, update.$setOnInsert);
+    }
+    if (doc && update.$set) Object.assign(doc, update.$set);
+    return { acknowledged: true, modifiedCount: doc ? 1 : 0, upsertedCount: options.upsert ? 1 : 0 };
+  }),
+  find: jest.fn((filter = {}) => ({
+    lean: async () => store.filter((d) => matches(d, filter)),
+    sort: () => ({ lean: async () => store.filter((d) => matches(d, filter)) })
+  }))
+};
+
+jest.mock('../../src/models', () => ({
+  OracleProvenanceRecord: MockOracleProvenanceRecord
+}));
+
+jest.mock('../../src/config/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  oracle: jest.fn()
+}));
+
+const recorder = require('../../src/services/oracle/OracleProvenanceRecorder');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+
+/** A consensus decision as produced by OracleConsensusEngine.evaluate(). */
+function makeDecision() {
+  return {
+    finalOutcome: 'yes',
+    consensusReached: true,
+    agreementRatio: 0.82,
+    totalWeight: 1.1,
+    weightByOutcome: { yes: 0.9, no: 0.2 },
+    participants: [
+      { source: 'coingecko', outcome: 'yes', value: 105000, confidence: 0.95, weight: 0.5, ageMs: 1000 },
+      { source: 'chainlink', outcome: 'yes', value: 104800, confidence: 0.9, weight: 0.4, ageMs: 2000 }
+    ],
+    rejected: {
+      invalid: [{ source: 'news-api', reason: 'missing_source_or_outcome' }],
+      stale: [{ source: 'sports-api', timestamp: '2026-01-15T11:40:00Z', ageMs: 1200000, maxAgeMs: 300000 }],
+      outliers: []
+    },
+    consensusThreshold: 0.6,
+    minResponses: 1,
+    evaluatedResponseCount: 4,
+    evaluatedAt: new Date(NOW).toISOString()
+  };
+}
+
+/** Raw provider results matching the decision above. */
+function makeResults() {
+  return [
+    {
+      source: 'coingecko',
+      outcome: 'yes',
+      confidence: 0.95,
+      data: { source: 'coingecko', symbol: 'bitcoin', currentPrice: 105000, targetPrice: 100000, condition: 'above', apiKey: 'super-secret-key' },
+      timestamp: new Date(NOW - 1000).toISOString()
+    },
+    {
+      source: 'chainlink',
+      outcome: 'yes',
+      confidence: 0.9,
+      data: { source: 'chainlink', feedId: 'BTC/USD', currentPrice: 104800, authorization: 'Bearer abc.def' },
+      timestamp: new Date(NOW - 2000).toISOString()
+    },
+    {
+      source: 'sports-api',
+      outcome: 'no',
+      confidence: 0.7,
+      data: { source: 'sports-api', gameId: 'game-1' },
+      timestamp: new Date(NOW - 1200000).toISOString()
+    },
+    {
+      source: 'news-api',
+      outcome: undefined,
+      confidence: 0.5,
+      data: { source: 'news-api', sentiment: 'neutral' },
+      timestamp: new Date(NOW - 3000).toISOString()
+    }
+  ];
+}
+
+beforeEach(() => {
+  store = [];
+  autoId = 1;
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Multi-provider attempt
+// ---------------------------------------------------------------------------
+
+describe('recordResolutionAttempt — multi-provider', () => {
+  it('persists one provenance record per raw provider response', async () => {
+    const batchId = await recorder.recordResolutionAttempt({
+      marketId: 'MKT-1',
+      results: makeResults(),
+      decision: makeDecision()
+    });
+
+    expect(batchId).toEqual(expect.stringContaining('MKT-1:'));
+    expect(store).toHaveLength(4);
+    expect(store.map((r) => r.provider).sort()).toEqual(
+      ['chainlink', 'coingecko', 'news-api', 'sports-api']
+    );
+    store.forEach((r) => {
+      expect(r.batchId).toBe(batchId);
+      expect(r.marketId).toBe('MKT-1');
+      expect(r.consensusContext).toBeTruthy();
+    });
+  });
+
+  it('assigns the correct validation status to each response', async () => {
+    await recorder.recordResolutionAttempt({
+      marketId: 'MKT-1',
+      results: makeResults(),
+      decision: makeDecision()
+    });
+
+    const byProvider = Object.fromEntries(store.map((r) => [r.provider, r]));
+
+    expect(byProvider.coingecko.validationStatus).toBe('valid');
+    expect(byProvider.coingecko.participatedInConsensus).toBe(true);
+    expect(byProvider.chainlink.validationStatus).toBe('valid');
+
+    expect(byProvider['sports-api'].validationStatus).toBe('stale');
+    expect(byProvider['sports-api'].stale).toBe(true);
+    expect(byProvider['sports-api'].rejectionReason).toBe('freshness_violation');
+    expect(byProvider['sports-api'].participatedInConsensus).toBe(false);
+
+    expect(byProvider['news-api'].validationStatus).toBe('rejected');
+    expect(byProvider['news-api'].rejectionReason).toBe('validation_failure');
+    expect(byProvider['news-api'].participatedInConsensus).toBe(false);
+  });
+
+  it('keeps rejected and stale observations queryable (they do not disappear)', async () => {
+    await recorder.recordResolutionAttempt({
+      marketId: 'MKT-1',
+      results: makeResults(),
+      decision: makeDecision()
+    });
+
+    const excluded = store.filter((r) => r.validationStatus !== 'valid');
+    expect(excluded.map((r) => r.provider).sort()).toEqual(['news-api', 'sports-api']);
+    excluded.forEach((r) => {
+      expect(r.rejectionReason).toBeTruthy();
+      expect(r.rejectionDetail).toBeTruthy();
+    });
+  });
+
+  it('is idempotent when the same attempt is recorded twice', async () => {
+    const batchId = await recorder.recordResolutionAttempt({
+      marketId: 'MKT-1',
+      results: makeResults(),
+      decision: makeDecision(),
+      batchId: 'MKT-1:fixed-batch'
+    });
+    await recorder.recordResolutionAttempt({
+      marketId: 'MKT-1',
+      results: makeResults(),
+      decision: makeDecision(),
+      batchId
+    });
+
+    expect(store).toHaveLength(4);
+  });
+
+  it('never persists credentials from provider response metadata', async () => {
+    await recorder.recordResolutionAttempt({
+      marketId: 'MKT-1',
+      results: makeResults(),
+      decision: makeDecision()
+    });
+
+    const serialized = JSON.stringify(store);
+    expect(serialized).not.toContain('super-secret-key');
+    expect(serialized).not.toContain('Bearer abc.def');
+
+    const coingecko = store.find((r) => r.provider === 'coingecko');
+    expect(coingecko.responseMetadata.apiKey).toBe('[redacted]');
+    expect(coingecko.responseMetadata.symbol).toBe('bitcoin');
+  });
+
+  it('returns null and writes nothing when there are no results', async () => {
+    const batchId = await recorder.recordResolutionAttempt({
+      marketId: 'MKT-1',
+      results: [],
+      decision: makeDecision()
+    });
+    expect(batchId).toBeNull();
+    expect(store).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale response handling
+// ---------------------------------------------------------------------------
+
+describe('recordResolutionAttempt — stale response', () => {
+  it('records freshness detail and excludes the stale response from consensus', async () => {
+    await recorder.recordResolutionAttempt({
+      marketId: 'MKT-2',
+      results: makeResults(),
+      decision: makeDecision()
+    });
+
+    const stale = store.find((r) => r.provider === 'sports-api');
+    expect(stale.validationStatus).toBe('stale');
+    expect(stale.freshness).toEqual({ ageMs: 1200000, maxAgeMs: 300000 });
+    expect(stale.rejectionDetail).toContain('exceeds max staleness');
+    expect(stale.contributedToResolution).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Outlier / malformed response
+// ---------------------------------------------------------------------------
+
+describe('recordResolutionAttempt — outlier and malformed responses', () => {
+  it('classifies an outlier response as rejected with the outlier reason', async () => {
+    const decision = makeDecision();
+    decision.rejected.outliers = [
+      { source: 'chainlink', value: 999999, robustZ: 12.4, threshold: 3.5 }
+    ];
+    decision.participants = decision.participants.filter((p) => p.source !== 'chainlink');
+
+    await recorder.recordResolutionAttempt({
+      marketId: 'MKT-3',
+      results: makeResults(),
+      decision
+    });
+
+    const chainlink = store.find((r) => r.provider === 'chainlink');
+    expect(chainlink.validationStatus).toBe('rejected');
+    expect(chainlink.rejectionReason).toBe('outlier');
+    expect(chainlink.rejectionDetail).toContain('z-score');
+  });
+
+  it('classifies an invalid-timestamp response as a malformed_response rejection', async () => {
+    const decision = makeDecision();
+    decision.rejected.invalid = [{ source: 'news-api', reason: 'invalid_timestamp' }];
+
+    await recorder.recordResolutionAttempt({
+      marketId: 'MKT-3',
+      results: makeResults(),
+      decision
+    });
+
+    const news = store.find((r) => r.provider === 'news-api');
+    expect(news.validationStatus).toBe('rejected');
+    expect(news.rejectionReason).toBe('malformed_response');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolution linkage
+// ---------------------------------------------------------------------------
+
+describe('linkResolution', () => {
+  it('links only contributing observations to the final resolution', async () => {
+    const batchId = await recorder.recordResolutionAttempt({
+      marketId: 'MKT-4',
+      results: makeResults(),
+      decision: makeDecision()
+    });
+
+    const linked = await recorder.linkResolution({
+      marketId: 'MKT-4',
+      batchId,
+      resolution: {
+        resolvedOutcome: 'yes',
+        resolvedAt: new Date(NOW),
+        resolutionTransactionHash: 'stellar-tx-hash-1',
+        consensusReached: true,
+        agreementRatio: 0.82
+      }
+    });
+
+    expect(linked).toBe(4);
+
+    const byProvider = Object.fromEntries(store.map((r) => [r.provider, r]));
+    // Accepted + outcome matches resolved outcome → contributed
+    expect(byProvider.coingecko.contributedToResolution).toBe(true);
+    expect(byProvider.chainlink.contributedToResolution).toBe(true);
+    // Stale / rejected → never contribute, even after linkage
+    expect(byProvider['sports-api'].contributedToResolution).toBe(false);
+    expect(byProvider['news-api'].contributedToResolution).toBe(false);
+
+    store.forEach((r) => {
+      expect(r.resolutionRef.resolutionTransactionHash).toBe('stellar-tx-hash-1');
+      expect(r.resolutionRef.resolvedOutcome).toBe('yes');
+    });
+  });
+
+  it('does not change a rejected/stale record\'s validation status', async () => {
+    const batchId = await recorder.recordResolutionAttempt({
+      marketId: 'MKT-5',
+      results: makeResults(),
+      decision: makeDecision()
+    });
+
+    await recorder.linkResolution({
+      marketId: 'MKT-5',
+      batchId,
+      resolution: { resolvedOutcome: 'yes', resolvedAt: new Date(NOW), resolutionTransactionHash: 'tx' }
+    });
+
+    const stale = store.find((r) => r.provider === 'sports-api');
+    const rejected = store.find((r) => r.provider === 'news-api');
+    expect(stale.validationStatus).toBe('stale');
+    expect(rejected.validationStatus).toBe('rejected');
+  });
+
+  it('returns 0 when there is no batch to link', async () => {
+    const linked = await recorder.linkResolution({
+      marketId: 'MKT-6',
+      batchId: 'does-not-exist',
+      resolution: { resolvedOutcome: 'yes' }
+    });
+    expect(linked).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('deriveVerdict', () => {
+  it('marks a participant as valid', () => {
+    const decision = makeDecision();
+    const verdict = recorder.deriveVerdict({ source: 'coingecko' }, decision);
+    expect(verdict.validationStatus).toBe('valid');
+    expect(verdict.participatedInConsensus).toBe(true);
+  });
+
+  it('marks an unknown source as rejected rather than dropping it', () => {
+    const verdict = recorder.deriveVerdict({ source: 'ghost' }, makeDecision());
+    expect(verdict.validationStatus).toBe('rejected');
+    expect(verdict.rejectionReason).toBe('validation_failure');
+  });
+});
+
+describe('sanitizeMetadata', () => {
+  it('redacts sensitive keys at any depth', () => {
+    const clean = recorder.sanitizeMetadata({
+      symbol: 'btc',
+      nested: { secret: 'x', apiKey: 'y', ok: 1 },
+      token: 'z'
+    });
+    expect(clean.symbol).toBe('btc');
+    expect(clean.nested.ok).toBe(1);
+    expect(clean.nested.secret).toBe('[redacted]');
+    expect(clean.nested.apiKey).toBe('[redacted]');
+    expect(clean.token).toBe('[redacted]');
+  });
+});

--- a/backend/src/controllers/oracleProvenanceController.js
+++ b/backend/src/controllers/oracleProvenanceController.js
@@ -1,0 +1,152 @@
+const { Market, OracleProvenanceRecord } = require('../models');
+const logger = require('../config/logger');
+const { NotFoundError } = require('../middleware/errorHandler');
+
+/**
+ * Oracle Data Provenance API (#241)
+ *
+ * GET /api/markets/:id/resolution/provenance
+ *
+ * Audit-friendly view of the OFF-CHAIN oracle-provider layer for a market: every
+ * provider response that entered the resolution pipeline, its validation verdict
+ * (valid / rejected / stale) and reason, whether it participated in consensus,
+ * and — for a resolved market — which observations actually contributed to the
+ * final outcome plus the consensus decision context.
+ *
+ * Complementary to GET /api/markets/:id/resolution, which exposes the on-chain
+ * submission/finalisation trail.
+ */
+
+/** Map a stored provenance record to the public, audit-friendly shape. */
+function toObservation(record) {
+  return {
+    provider: record.provider,
+    providerRequestId: record.providerRequestId || null,
+    batchId: record.batchId,
+    receivedAt: record.receivedAt,
+    normalizedOutcome: record.normalizedOutcome || null,
+    confidence: record.confidence ?? null,
+    numericValue: record.numericValue ?? null,
+    sourceValue: record.sourceValue ?? null,
+    responseMetadata: record.responseMetadata ?? null,
+    validationStatus: record.validationStatus,
+    rejectionReason: record.rejectionReason || null,
+    rejectionDetail: record.rejectionDetail || null,
+    stale: Boolean(record.stale),
+    freshness: record.freshness || null,
+    participatedInConsensus: Boolean(record.participatedInConsensus),
+    weightInConsensus: record.weightInConsensus ?? null,
+    contributedToResolution: Boolean(record.contributedToResolution)
+  };
+}
+
+/**
+ * Group records by resolution attempt (batchId) so the decision path is
+ * reconstructable per attempt, newest attempt last.
+ */
+function buildAttempts(records) {
+  const byBatch = new Map();
+
+  for (const record of records) {
+    if (!byBatch.has(record.batchId)) {
+      byBatch.set(record.batchId, {
+        batchId: record.batchId,
+        recordedAt: record.recordedAt || record.createdAt || record.receivedAt,
+        consensusContext: record.consensusContext || null,
+        resolutionRef: record.resolutionRef || null,
+        observations: []
+      });
+    }
+    byBatch.get(record.batchId).observations.push(record);
+  }
+
+  return Array.from(byBatch.values())
+    .sort((a, b) => new Date(a.recordedAt).getTime() - new Date(b.recordedAt).getTime())
+    .map((attempt) => {
+      const accepted = attempt.observations.filter((o) => o.validationStatus === 'valid');
+      const rejected = attempt.observations.filter((o) => o.validationStatus === 'rejected');
+      const stale = attempt.observations.filter((o) => o.validationStatus === 'stale');
+      const contributed = attempt.observations.filter((o) => o.contributedToResolution);
+
+      return {
+        batchId: attempt.batchId,
+        recordedAt: attempt.recordedAt,
+        observationCount: attempt.observations.length,
+        acceptedCount: accepted.length,
+        rejectedCount: rejected.length,
+        staleCount: stale.length,
+        acceptedProviders: accepted.map((o) => o.provider),
+        rejectedProviders: rejected.map((o) => ({
+          provider: o.provider,
+          reason: o.rejectionReason
+        })),
+        staleProviders: stale.map((o) => o.provider),
+        contributingProviders: contributed.map((o) => o.provider),
+        consensusContext: attempt.consensusContext || null,
+        resolutionRef: attempt.resolutionRef || null
+      };
+    });
+}
+
+class OracleProvenanceController {
+  /**
+   * GET /api/markets/:id/resolution/provenance
+   */
+  static async getMarketProvenance(req, res) {
+    const { id } = req.params;
+
+    const market = await Market.findOne({ marketId: id }).lean();
+    if (!market) {
+      throw new NotFoundError('Market not found');
+    }
+
+    const records = await OracleProvenanceRecord.find({ marketId: id })
+      .sort({ receivedAt: 1 })
+      .lean();
+
+    const observations = records.map(toObservation);
+    const attempts = buildAttempts(records);
+    const latestAttempt = attempts.length > 0 ? attempts[attempts.length - 1] : null;
+
+    // A resolved market with no provenance records predates this feature; say so
+    // rather than fabricating a trail (#241 §21).
+    const marketResolved = market.status === 'resolved' || Boolean(market.resolvedOutcome);
+    const legacyResolution = marketResolved && records.length === 0;
+
+    logger.info('Oracle provenance data assembled', {
+      marketId: id,
+      observationCount: observations.length,
+      attemptCount: attempts.length,
+      legacyResolution
+    });
+
+    res.json({
+      success: true,
+      data: {
+        marketId: id,
+        resolution: {
+          status: market.status,
+          resolvedOutcome: market.resolvedOutcome || null,
+          resolvedAt: market.resolvedAt || null,
+          resolvedBy: market.resolvedBy || null,
+          resolutionTransactionHash: market.resolutionTransactionHash || null,
+          finalizationTxHash: market.resolutionFinalizationTxHash || null,
+          finalizationTimestamp: market.resolutionFinalizationTimestamp || null
+        },
+        observations,
+        attempts,
+        decision_context: latestAttempt
+          ? {
+              batchId: latestAttempt.batchId,
+              consensusContext: latestAttempt.consensusContext,
+              resolutionRef: latestAttempt.resolutionRef,
+              contributingProviders: latestAttempt.contributingProviders
+            }
+          : null,
+        legacy_resolution: legacyResolution
+      }
+    });
+  }
+}
+
+module.exports = OracleProvenanceController;

--- a/backend/src/models/OracleProvenanceRecord.js
+++ b/backend/src/models/OracleProvenanceRecord.js
@@ -1,0 +1,207 @@
+const mongoose = require('mongoose');
+
+/**
+ * OracleProvenanceRecord (#241)
+ *
+ * Append-oriented provenance trail for the OFF-CHAIN oracle-provider layer.
+ *
+ * Each document captures a single oracle provider response that entered the
+ * resolution pipeline for a market, together with the verdict the backend's
+ * `OracleConsensusEngine` reached about it (valid / rejected / stale), the
+ * reason it was rejected, whether it participated in consensus, and — once the
+ * market is resolved — whether it contributed to the final outcome.
+ *
+ * This is complementary to `ResolutionEvent`, which records the ON-CHAIN oracle
+ * submissions indexed from Soroban contract events. `ResolutionEvent` answers
+ * "what did the contract see and finalize"; `OracleProvenanceRecord` answers
+ * "what did each external data source return and why was it accepted or not".
+ *
+ * Historical-reconstruction rules (see issue #241 §13):
+ *   - `validationStatus`, `rejectionReason` and the raw observation fields are
+ *     written once and never mutated. A response that was rejected stays
+ *     rejected even if a later attempt produces a valid answer.
+ *   - Only the resolution linkage fields (`resolutionRef`,
+ *     `contributedToResolution`) are filled in after the fact, and only after
+ *     the real resolution state transition has succeeded.
+ */
+
+const VALIDATION_STATUSES = ['valid', 'rejected', 'stale'];
+
+// Structured reason codes — prefer these over free-form strings. `rejectionDetail`
+// carries the human-readable explanation.
+const REJECTION_REASONS = [
+  'invalid_value',
+  'stale_timestamp',
+  'malformed_response',
+  'provider_error',
+  'freshness_violation',
+  'validation_failure',
+  'outlier',
+  'insufficient_confidence'
+];
+
+const freshnessSchema = new mongoose.Schema(
+  {
+    ageMs: { type: Number },
+    maxAgeMs: { type: Number }
+  },
+  { _id: false }
+);
+
+const resolutionRefSchema = new mongoose.Schema(
+  {
+    resolvedOutcome: { type: String },
+    resolvedAt: { type: Date },
+    resolutionTransactionHash: { type: String },
+    resolvedBy: { type: String },
+    consensusReached: { type: Boolean },
+    agreementRatio: { type: Number }
+  },
+  { _id: false }
+);
+
+const oracleProvenanceRecordSchema = new mongoose.Schema(
+  {
+    marketId: {
+      type: String,
+      required: true,
+      index: true
+    },
+
+    // Groups every observation produced by a single resolution attempt so the
+    // decision path can be reconstructed and linked to a resolution as a unit.
+    batchId: {
+      type: String,
+      required: true,
+      index: true
+    },
+
+    // --- Provider identity -------------------------------------------------
+    provider: {
+      type: String,
+      required: true
+    },
+    // Provider-side request/source reference where the provider exposes one
+    // (e.g. CoinGecko symbol, Chainlink feed id, sports game id).
+    providerRequestId: {
+      type: String,
+      default: null
+    },
+
+    // --- Observation -----------------------------------------------------
+    receivedAt: {
+      type: Date,
+      required: true
+    },
+    normalizedOutcome: {
+      type: String,
+      enum: ['yes', 'no', null],
+      default: null
+    },
+    confidence: {
+      type: Number,
+      min: 0,
+      max: 1,
+      default: null
+    },
+    // Normalised numeric measurement when the provider supplies one (used by the
+    // consensus engine for outlier detection). Null for non-numeric sources.
+    numericValue: {
+      type: Number,
+      default: null
+    },
+    // The normalised source payload as returned by the provider, AFTER
+    // sanitisation. Never contains API keys, tokens or auth headers.
+    sourceValue: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null
+    },
+    responseMetadata: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null
+    },
+
+    // --- Verdict -------------------------------------------------------
+    validationStatus: {
+      type: String,
+      required: true,
+      enum: VALIDATION_STATUSES
+    },
+    rejectionReason: {
+      type: String,
+      enum: [...REJECTION_REASONS, null],
+      default: null
+    },
+    rejectionDetail: {
+      type: String,
+      default: null
+    },
+    stale: {
+      type: Boolean,
+      default: false
+    },
+    freshness: {
+      type: freshnessSchema,
+      default: null
+    },
+
+    // --- Consensus / resolution linkage --------------------------------
+    participatedInConsensus: {
+      type: Boolean,
+      default: false
+    },
+    weightInConsensus: {
+      type: Number,
+      default: null
+    },
+    // Snapshot of the consensus decision context for the batch. Duplicated onto
+    // each record so a single record is self-describing for audit queries.
+    consensusContext: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null
+    },
+
+    // Filled in only after the market's real resolution transition succeeds.
+    contributedToResolution: {
+      type: Boolean,
+      default: false
+    },
+    resolutionRef: {
+      type: resolutionRefSchema,
+      default: null
+    },
+
+    recordedAt: {
+      type: Date,
+      default: Date.now
+    }
+  },
+  {
+    timestamps: true,
+    collection: 'oracle_provenance'
+  }
+);
+
+// One observation per (attempt, provider) — keeps re-recording an attempt
+// idempotent without ever fabricating history for a new attempt.
+oracleProvenanceRecordSchema.index({ batchId: 1, provider: 1 }, { unique: true });
+
+// Audit query patterns: timeline for a market, filter by verdict, per-provider
+// history, and lookup by the resolution a record contributed to.
+oracleProvenanceRecordSchema.index({ marketId: 1, receivedAt: -1 });
+oracleProvenanceRecordSchema.index({ marketId: 1, validationStatus: 1 });
+oracleProvenanceRecordSchema.index({ provider: 1, receivedAt: -1 });
+oracleProvenanceRecordSchema.index(
+  { 'resolutionRef.resolutionTransactionHash': 1 },
+  { sparse: true }
+);
+
+const OracleProvenanceRecord = mongoose.model(
+  'OracleProvenanceRecord',
+  oracleProvenanceRecordSchema
+);
+
+OracleProvenanceRecord.VALIDATION_STATUSES = VALIDATION_STATUSES;
+OracleProvenanceRecord.REJECTION_REASONS = REJECTION_REASONS;
+
+module.exports = OracleProvenanceRecord;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -4,6 +4,7 @@ const Trade = require('./Trade');
 const Position = require('./Position');
 const IndexedEvent = require('./IndexedEvent');
 const ResolutionEvent = require('./ResolutionEvent');
+const OracleProvenanceRecord = require('./OracleProvenanceRecord');
 const MarketEvent = require('./MarketEvent');
 const MarketSnapshot = require('./MarketSnapshot');
 const Alert = require('./Alert');
@@ -29,6 +30,7 @@ module.exports = {
   Position,
   IndexedEvent,
   ResolutionEvent,
+  OracleProvenanceRecord,
   MarketEvent,
   MarketSnapshot,
   Alert,

--- a/backend/src/routes/markets.js
+++ b/backend/src/routes/markets.js
@@ -78,11 +78,18 @@ router.get('/trending/v2',
 );
 
 const resolutionController = require('../controllers/resolutionController');
+const oracleProvenanceController = require('../controllers/oracleProvenanceController');
 
 // Get market resolution transparency data
 router.get('/:id/resolution',
   optionalAuth,
   asyncHandler(resolutionController.getMarketResolution)
+);
+
+// Get oracle data provenance for a market's resolution (#241)
+router.get('/:id/resolution/provenance',
+  optionalAuth,
+  asyncHandler(oracleProvenanceController.getMarketProvenance)
 );
 
 // Get specific market by ID

--- a/backend/src/services/backgroundJobs.js
+++ b/backend/src/services/backgroundJobs.js
@@ -183,7 +183,11 @@ class BackgroundJobs {
           market.resolve(oracleResult.outcome, 'oracle', oracleResult.transactionHash);
           await market.save();
           resolved = true;
-          
+
+          // Link the oracle provenance trail to this resolution now that the
+          // market state transition has been persisted (#241). Best-effort.
+          await oracleService.linkResolutionProvenance(market.marketId, oracleResult, market);
+
           logger.oracle('Market auto-resolved', {
             marketId: market.marketId,
             outcome: oracleResult.outcome,
@@ -262,6 +266,9 @@ class BackgroundJobs {
 
     market.resolve(oracleResult.outcome, 'oracle', oracleResult.transactionHash);
     await market.save();
+
+    // Link the oracle provenance trail recorded during the retry attempt (#241).
+    await oracleService.linkResolutionProvenance(market.marketId, oracleResult, market);
 
     websocketHandler.sendUserNotification(market.creatorWalletAddress, {
       type: 'market_resolved',

--- a/backend/src/services/oracle/OracleProvenanceRecorder.js
+++ b/backend/src/services/oracle/OracleProvenanceRecorder.js
@@ -1,0 +1,358 @@
+/**
+ * OracleProvenanceRecorder (#241)
+ *
+ * Turns the output of a resolution attempt — the raw provider responses plus the
+ * `OracleConsensusEngine` decision — into a durable, append-oriented provenance
+ * trail (`OracleProvenanceRecord`). Also links those records to a market
+ * resolution once the real resolution state transition has succeeded.
+ *
+ * Every method is best-effort: a persistence failure is logged and swallowed so
+ * it can never interrupt or fail a market resolution. Auditability is a goal,
+ * but it must not come at the cost of blocking resolution — records that fail to
+ * persist are logged loudly enough to be noticed and repaired.
+ */
+
+const crypto = require('crypto');
+const logger = require('../../config/logger');
+const { OracleProvenanceRecord } = require('../../models');
+
+// Keys whose values must never be persisted, matched case-insensitively as a
+// substring of the key name.
+const SENSITIVE_KEY_PATTERN = /(api[_-]?key|secret|token|authorization|auth|password|passphrase|credential|bearer|cookie|session|private[_-]?key|signature)/i;
+
+const MAX_METADATA_DEPTH = 4;
+const MAX_METADATA_STRING = 2000;
+
+/**
+ * Recursively strip sensitive keys and cap size/depth so we never persist
+ * credentials or unbounded blobs. Returns a plain, JSON-safe object.
+ */
+function sanitizeMetadata(value, depth = 0) {
+  if (value === null || value === undefined) return null;
+
+  if (typeof value === 'string') {
+    return value.length > MAX_METADATA_STRING
+      ? `${value.slice(0, MAX_METADATA_STRING)}…[truncated]`
+      : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+
+  if (value instanceof Date) return value.toISOString();
+
+  if (depth >= MAX_METADATA_DEPTH) return '[depth-limited]';
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 50).map((item) => sanitizeMetadata(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        out[key] = '[redacted]';
+        continue;
+      }
+      out[key] = sanitizeMetadata(val, depth + 1);
+    }
+    return out;
+  }
+
+  return null;
+}
+
+/**
+ * Build a stable batch id for one resolution attempt.
+ */
+function makeBatchId(marketId) {
+  return `${marketId}:${Date.now()}:${crypto.randomBytes(4).toString('hex')}`;
+}
+
+/**
+ * Compact, self-describing snapshot of the consensus decision for a batch.
+ */
+function buildConsensusContext(decision) {
+  if (!decision || typeof decision !== 'object') return null;
+
+  const rejected = decision.rejected || {};
+  return {
+    providersConsidered: decision.evaluatedResponseCount ?? null,
+    providersAccepted: (decision.participants || []).map((p) => p.source),
+    providersRejected: {
+      stale: (rejected.stale || []).map((r) => r.source),
+      outliers: (rejected.outliers || []).map((r) => r.source),
+      invalid: (rejected.invalid || []).map((r) => r.source)
+    },
+    valuesUsed: (decision.participants || []).map((p) => ({
+      source: p.source,
+      outcome: p.outcome,
+      value: p.value ?? null,
+      weight: p.weight
+    })),
+    weightByOutcome: decision.weightByOutcome || null,
+    totalWeight: decision.totalWeight ?? null,
+    agreementRatio: decision.agreementRatio ?? null,
+    consensusThreshold: decision.consensusThreshold ?? null,
+    minResponses: decision.minResponses ?? null,
+    finalOutcome: decision.finalOutcome ?? null,
+    consensusReached: Boolean(decision.consensusReached),
+    evaluatedAt: decision.evaluatedAt || new Date().toISOString()
+  };
+}
+
+/**
+ * Cross-reference one raw provider result against the consensus decision to
+ * derive its validation verdict. Pure function — easy to unit test.
+ *
+ * @param {Object} result   raw provider result { source, outcome, confidence, data, timestamp }
+ * @param {Object} decision OracleConsensusEngine decision
+ * @returns {Object} verdict fields for an OracleProvenanceRecord
+ */
+function deriveVerdict(result, decision) {
+  const source = result.source;
+  const rejected = (decision && decision.rejected) || { stale: [], outliers: [], invalid: [] };
+
+  const participant = (decision?.participants || []).find((p) => p.source === source);
+  if (participant) {
+    return {
+      validationStatus: 'valid',
+      rejectionReason: null,
+      rejectionDetail: null,
+      stale: false,
+      freshness: participant.ageMs !== undefined
+        ? { ageMs: participant.ageMs, maxAgeMs: null }
+        : null,
+      participatedInConsensus: true,
+      weightInConsensus: participant.weight ?? null
+    };
+  }
+
+  const staleEntry = (rejected.stale || []).find((r) => r.source === source);
+  if (staleEntry) {
+    return {
+      validationStatus: 'stale',
+      rejectionReason: 'freshness_violation',
+      rejectionDetail: `Response age ${staleEntry.ageMs}ms exceeds max staleness ${staleEntry.maxAgeMs}ms`,
+      stale: true,
+      freshness: { ageMs: staleEntry.ageMs ?? null, maxAgeMs: staleEntry.maxAgeMs ?? null },
+      participatedInConsensus: false,
+      weightInConsensus: null
+    };
+  }
+
+  const outlierEntry = (rejected.outliers || []).find((r) => r.source === source);
+  if (outlierEntry) {
+    return {
+      validationStatus: 'rejected',
+      rejectionReason: 'outlier',
+      rejectionDetail: `Robust z-score ${outlierEntry.robustZ} exceeds threshold ${outlierEntry.threshold}`,
+      stale: false,
+      freshness: null,
+      participatedInConsensus: false,
+      weightInConsensus: null
+    };
+  }
+
+  const invalidEntry = (rejected.invalid || []).find((r) => r.source === source);
+  if (invalidEntry) {
+    const reasonCode = invalidEntry.reason === 'invalid_timestamp'
+      ? 'malformed_response'
+      : 'validation_failure';
+    return {
+      validationStatus: 'rejected',
+      rejectionReason: reasonCode,
+      rejectionDetail: `Consensus engine rejected response: ${invalidEntry.reason}`,
+      stale: false,
+      freshness: null,
+      participatedInConsensus: false,
+      weightInConsensus: null
+    };
+  }
+
+  // Source produced a result but is absent from both participants and the
+  // rejection buckets (e.g. removed as part of an outlier source-set). Record it
+  // as rejected rather than letting it vanish.
+  return {
+    validationStatus: 'rejected',
+    rejectionReason: 'validation_failure',
+    rejectionDetail: 'Response was not included in the consensus evaluation',
+    stale: false,
+    freshness: null,
+    participatedInConsensus: false,
+    weightInConsensus: null
+  };
+}
+
+class OracleProvenanceRecorder {
+  /**
+   * Persist one provenance record per raw provider result for a resolution
+   * attempt. Returns the generated `batchId` (or a caller-supplied one) so the
+   * caller can later link the batch to a resolution. Never throws.
+   *
+   * @param {Object} params
+   * @param {string} params.marketId
+   * @param {Array}  params.results   raw provider results
+   * @param {Object} params.decision  OracleConsensusEngine decision
+   * @param {string} [params.batchId] override (used by tests / retries)
+   * @returns {Promise<string|null>} batchId, or null if nothing was recorded
+   */
+  async recordResolutionAttempt({ marketId, results, decision, batchId } = {}) {
+    if (!marketId || !Array.isArray(results) || results.length === 0) {
+      return null;
+    }
+
+    const resolvedBatchId = batchId || makeBatchId(marketId);
+    const consensusContext = buildConsensusContext(decision);
+    const now = new Date();
+
+    try {
+      let written = 0;
+      for (const result of results) {
+        const verdict = deriveVerdict(result, decision);
+        const data = result.data || {};
+        const numericValue = Number.isFinite(data.currentPrice)
+          ? data.currentPrice
+          : (Number.isFinite(result.value) ? result.value : null);
+
+        const parsedReceivedAt = result.timestamp ? new Date(result.timestamp) : now;
+        const receivedAt = Number.isNaN(parsedReceivedAt.getTime()) ? now : parsedReceivedAt;
+
+        // Upsert keyed on (batchId, provider): re-recording the same attempt is
+        // idempotent, while a new attempt (new batchId) always creates fresh
+        // history rather than mutating the old observation.
+        await OracleProvenanceRecord.updateOne(
+          { batchId: resolvedBatchId, provider: result.source },
+          {
+            $setOnInsert: {
+              marketId: String(marketId),
+              batchId: resolvedBatchId,
+              provider: result.source,
+              providerRequestId:
+                data.symbol || data.feedId || data.gameId || data.reference || null,
+              receivedAt,
+              normalizedOutcome:
+                result.outcome === 'yes' || result.outcome === 'no' ? result.outcome : null,
+              confidence: Number.isFinite(result.confidence) ? result.confidence : null,
+              numericValue,
+              sourceValue: sanitizeMetadata({
+                outcome: result.outcome,
+                confidence: result.confidence,
+                value: numericValue
+              }),
+              responseMetadata: sanitizeMetadata(data),
+              validationStatus: verdict.validationStatus,
+              rejectionReason: verdict.rejectionReason,
+              rejectionDetail: verdict.rejectionDetail,
+              stale: verdict.stale,
+              freshness: verdict.freshness,
+              participatedInConsensus: verdict.participatedInConsensus,
+              weightInConsensus: verdict.weightInConsensus,
+              consensusContext,
+              contributedToResolution: false,
+              resolutionRef: null,
+              recordedAt: now
+            }
+          },
+          { upsert: true }
+        );
+        written += 1;
+      }
+
+      logger.oracle('Oracle provenance recorded', {
+        marketId,
+        batchId: resolvedBatchId,
+        observations: written,
+        accepted: consensusContext ? consensusContext.providersAccepted.length : 0
+      });
+
+      return resolvedBatchId;
+    } catch (error) {
+      logger.error('Failed to record oracle provenance', {
+        marketId,
+        batchId: resolvedBatchId,
+        error: error.message
+      });
+      return resolvedBatchId;
+    }
+  }
+
+  /**
+   * Link a recorded batch to a finalised market resolution. Only ever sets the
+   * linkage fields — it never rewrites a record's validation verdict, so a
+   * response that was rejected/stale stays that way in the historical trail.
+   *
+   * Must be called only AFTER the real resolution state transition has
+   * succeeded (issue #241 §9, §20).
+   *
+   * @param {Object} params
+   * @param {string} params.marketId
+   * @param {string} params.batchId
+   * @param {Object} params.resolution { resolvedOutcome, resolvedAt, resolutionTransactionHash, resolvedBy, consensusReached, agreementRatio }
+   * @returns {Promise<number>} number of records linked
+   */
+  async linkResolution({ marketId, batchId, resolution } = {}) {
+    if (!marketId || !batchId || !resolution || !resolution.resolvedOutcome) {
+      return 0;
+    }
+
+    const resolutionRef = {
+      resolvedOutcome: resolution.resolvedOutcome,
+      resolvedAt: resolution.resolvedAt || new Date(),
+      resolutionTransactionHash: resolution.resolutionTransactionHash || null,
+      resolvedBy: resolution.resolvedBy || 'oracle',
+      consensusReached:
+        resolution.consensusReached === undefined ? null : resolution.consensusReached,
+      agreementRatio:
+        resolution.agreementRatio === undefined ? null : resolution.agreementRatio
+    };
+
+    try {
+      const records = await OracleProvenanceRecord.find({ marketId: String(marketId), batchId }).lean();
+      if (!records || records.length === 0) {
+        logger.warn('No oracle provenance records to link for resolution', { marketId, batchId });
+        return 0;
+      }
+
+      let linked = 0;
+      for (const record of records) {
+        // A record "contributed" iff it was accepted into consensus AND its
+        // outcome matches the outcome the market actually resolved to.
+        const contributed = Boolean(
+          record.participatedInConsensus &&
+            record.normalizedOutcome &&
+            record.normalizedOutcome === resolution.resolvedOutcome
+        );
+
+        await OracleProvenanceRecord.updateOne(
+          { _id: record._id },
+          { $set: { contributedToResolution: contributed, resolutionRef } }
+        );
+        linked += 1;
+      }
+
+      logger.oracle('Oracle provenance linked to resolution', {
+        marketId,
+        batchId,
+        linked,
+        resolvedOutcome: resolution.resolvedOutcome
+      });
+
+      return linked;
+    } catch (error) {
+      logger.error('Failed to link oracle provenance to resolution', {
+        marketId,
+        batchId,
+        error: error.message
+      });
+      return 0;
+    }
+  }
+}
+
+const instance = new OracleProvenanceRecorder();
+instance.sanitizeMetadata = sanitizeMetadata;
+instance.deriveVerdict = deriveVerdict;
+instance.buildConsensusContext = buildConsensusContext;
+instance.OracleProvenanceRecorder = OracleProvenanceRecorder;
+
+module.exports = instance;

--- a/backend/src/services/oracleService.js
+++ b/backend/src/services/oracleService.js
@@ -3,6 +3,7 @@ const { Market } = require('../models');
 const OracleProviderLoader = require('./oracle/OracleProviderLoader');
 const consensusEngine = require('./oracle/ConsensusEngine');
 const auditService = require('./auditService');
+const oracleProvenanceRecorder = require('./oracle/OracleProvenanceRecorder');
 
 const ANOMALY_THRESHOLD = 0.25; // 25% price drift threshold
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes cache
@@ -680,9 +681,62 @@ class OracleService {
 
     if (marketId) {
       this.recordConsensusAudit(marketId, decision);
+
+      // Provenance trail (#241): persist one record per raw provider response
+      // with its validation verdict, plus the consensus decision context, so a
+      // resolved market's oracle decision path can be reconstructed later. The
+      // returned batchId lets the resolution flow link these records to the
+      // final resolution once the on-chain/state transition succeeds.
+      const provenanceBatchId = `${marketId}:${Date.now()}:${Math.random().toString(16).slice(2, 10)}`;
+      aggregated.data.provenanceBatchId = provenanceBatchId;
+      Promise.resolve(
+        oracleProvenanceRecorder.recordResolutionAttempt({
+          marketId,
+          results,
+          decision,
+          batchId: provenanceBatchId
+        })
+      ).catch(error => {
+        logger.error('Oracle provenance recording failed', { marketId, error: error.message });
+      });
     }
 
     return aggregated;
+  }
+
+  /**
+   * Link a previously recorded provenance batch to a finalised resolution.
+   * Best-effort and safe to call only after the market state transition has
+   * been persisted (#241).
+   */
+  linkResolutionProvenance(marketId, oracleResult, market) {
+    const batchId = oracleResult?.data?.provenanceBatchId;
+    if (!marketId || !batchId) {
+      return Promise.resolve(0);
+    }
+
+    return Promise.resolve(
+      oracleProvenanceRecorder.linkResolution({
+        marketId,
+        batchId,
+        resolution: {
+          resolvedOutcome: oracleResult.outcome,
+          resolvedAt: market?.resolvedAt || new Date(),
+          resolutionTransactionHash:
+            oracleResult.transactionHash || market?.resolutionTransactionHash || null,
+          resolvedBy: 'oracle',
+          consensusReached: oracleResult?.consensusReached,
+          agreementRatio: oracleResult?.data?.consensus?.agreementRatio
+        }
+      })
+    ).catch(error => {
+      logger.error('Oracle provenance resolution linkage failed', {
+        marketId,
+        batchId,
+        error: error.message
+      });
+      return 0;
+    });
   }
 
   /**

--- a/docs/oracle-data-provenance.md
+++ b/docs/oracle-data-provenance.md
@@ -1,0 +1,213 @@
+# Oracle Data Provenance & Verification Layer (#241)
+
+## Purpose
+
+Every resolved market can be traced back through the oracle responses that
+contributed to the final resolution decision. The provenance layer preserves
+enough historical information to independently determine, for each oracle
+response that entered the resolution pipeline:
+
+- which oracle provider supplied the value
+- when the value was received
+- what value / metadata was supplied
+- whether the response was valid, rejected, or stale
+- why it was rejected (structured reason code + human-readable detail)
+- whether it participated in consensus
+- whether it contributed to the final market resolution
+- how the final resolution decision was reached (consensus decision context)
+
+## Where this sits
+
+The repository already exposes an **on-chain** resolution trail:
+
+| Layer | Model | API | Answers |
+|---|---|---|---|
+| On-chain submissions | `ResolutionEvent` (`resolution_events`) | `GET /api/markets/:id/resolution` | What the `oracle-resolver` contract collected and finalized |
+| **Off-chain provider provenance (this feature)** | `OracleProvenanceRecord` (`oracle_provenance`) | `GET /api/markets/:id/resolution/provenance` | What each external data source returned and why the backend accepted or rejected it |
+
+This feature **extends** the existing oracle architecture
+(`oracleService` + `OracleConsensusEngine`); it does not replace any of it.
+
+## Data model — `OracleProvenanceRecord`
+
+Collection: `oracle_provenance`. Append-oriented — the observation and verdict
+fields are written once and never mutated.
+
+| Field | Type | Notes |
+|---|---|---|
+| `marketId` | String | indexed |
+| `batchId` | String | groups all observations from one resolution attempt |
+| `provider` | String | e.g. `coingecko`, `chainlink`, `sports-api`, `news-api` |
+| `providerRequestId` | String | provider-side reference (symbol / feed id / game id) when available |
+| `receivedAt` | Date | when the provider response was produced |
+| `normalizedOutcome` | `'yes' \| 'no' \| null` | normalized provider outcome |
+| `confidence` | Number (0–1) | provider-reported confidence |
+| `numericValue` | Number | normalized numeric measurement, when the provider supplies one |
+| `sourceValue` | Mixed | sanitized normalized payload `{ outcome, confidence, value }` |
+| `responseMetadata` | Mixed | sanitized provider `data` block (never contains credentials) |
+| `validationStatus` | `'valid' \| 'rejected' \| 'stale'` | verdict from `OracleConsensusEngine` |
+| `rejectionReason` | enum \| null | `invalid_value`, `stale_timestamp`, `malformed_response`, `provider_error`, `freshness_violation`, `validation_failure`, `outlier`, `insufficient_confidence` |
+| `rejectionDetail` | String | human-readable explanation |
+| `stale` | Boolean | |
+| `freshness` | `{ ageMs, maxAgeMs }` | |
+| `participatedInConsensus` | Boolean | accepted into the weighted vote |
+| `weightInConsensus` | Number | effective weight applied |
+| `consensusContext` | Mixed | snapshot of the batch's consensus decision (see below) |
+| `contributedToResolution` | Boolean | set post-resolution: accepted **and** outcome matches the resolved outcome |
+| `resolutionRef` | `{ resolvedOutcome, resolvedAt, resolutionTransactionHash, resolvedBy, consensusReached, agreementRatio }` | set only after the real resolution transition succeeds |
+
+### Indexes
+
+- `{ batchId, provider }` unique — one observation per (attempt, provider); makes re-recording an attempt idempotent.
+- `{ marketId, receivedAt }` — market timeline.
+- `{ marketId, validationStatus }` — audit filter by verdict.
+- `{ provider, receivedAt }` — per-provider history.
+- `{ 'resolutionRef.resolutionTransactionHash' }` sparse — lookup by resolution.
+
+### `consensusContext` snapshot
+
+```json
+{
+  "providersConsidered": 4,
+  "providersAccepted": ["coingecko", "chainlink"],
+  "providersRejected": { "stale": ["sports-api"], "outliers": [], "invalid": ["news-api"] },
+  "valuesUsed": [{ "source": "coingecko", "outcome": "yes", "value": 105000, "weight": 0.48 }],
+  "weightByOutcome": { "yes": 0.9, "no": 0.2 },
+  "totalWeight": 1.1,
+  "agreementRatio": 0.82,
+  "consensusThreshold": 0.6,
+  "minResponses": 1,
+  "finalOutcome": "yes",
+  "consensusReached": true,
+  "evaluatedAt": "2026-01-15T12:00:00.000Z"
+}
+```
+
+## Integration points
+
+1. **`oracleService.aggregateResults(results, options)`** — after
+   `OracleConsensusEngine.evaluate()` produces its decision, a `batchId` is
+   generated, attached to the aggregated result as
+   `data.provenanceBatchId`, and `OracleProvenanceRecorder.recordResolutionAttempt()`
+   is invoked (fire-and-forget, mirroring the existing `recordConsensusAudit`
+   pattern). This covers `resolveWithFallback` and the oracle retry queue.
+2. **`backgroundJobs.processMarketExpiration` / `resolveMarketFromOracleRetry`** —
+   after `market.resolve(...)` and `market.save()` succeed,
+   `oracleService.linkResolutionProvenance(marketId, oracleResult, market)` links
+   the recorded batch to the resolution. Linkage happens **only after** the state
+   transition is persisted, so a resolution is never "successful" in the
+   provenance layer before it is real.
+
+`OracleProvenanceRecorder` is entirely best-effort: any persistence failure is
+logged and swallowed so it can never fail a market resolution. Records written
+during `aggregateResults` survive even if the later linkage step fails (they are
+simply left unlinked and logged).
+
+## API — `GET /api/markets/:id/resolution/provenance`
+
+`optionalAuth`, same conventions as `GET /api/markets/:id/resolution`.
+Returns HTTP 404 (standard error body) for an unknown market.
+
+```json
+{
+  "success": true,
+  "data": {
+    "marketId": "MKT-1",
+    "resolution": {
+      "status": "resolved",
+      "resolvedOutcome": "yes",
+      "resolvedAt": "2026-01-15T12:00:00.000Z",
+      "resolvedBy": "oracle",
+      "resolutionTransactionHash": "stellar-tx-1",
+      "finalizationTxHash": null,
+      "finalizationTimestamp": null
+    },
+    "observations": [
+      {
+        "provider": "coingecko",
+        "providerRequestId": "bitcoin",
+        "batchId": "MKT-1:1737033600000:ab12cd34",
+        "receivedAt": "2026-01-15T11:59:59.000Z",
+        "normalizedOutcome": "yes",
+        "confidence": 0.95,
+        "numericValue": 105000,
+        "sourceValue": { "outcome": "yes", "confidence": 0.95, "value": 105000 },
+        "responseMetadata": { "source": "coingecko", "symbol": "bitcoin" },
+        "validationStatus": "valid",
+        "rejectionReason": null,
+        "rejectionDetail": null,
+        "stale": false,
+        "freshness": null,
+        "participatedInConsensus": true,
+        "weightInConsensus": 0.48,
+        "contributedToResolution": true
+      }
+    ],
+    "attempts": [
+      {
+        "batchId": "MKT-1:1737033600000:ab12cd34",
+        "recordedAt": "2026-01-15T12:00:00.000Z",
+        "observationCount": 4,
+        "acceptedCount": 2,
+        "rejectedCount": 1,
+        "staleCount": 1,
+        "acceptedProviders": ["coingecko", "chainlink"],
+        "rejectedProviders": [{ "provider": "news-api", "reason": "validation_failure" }],
+        "staleProviders": ["sports-api"],
+        "contributingProviders": ["coingecko", "chainlink"],
+        "consensusContext": { "finalOutcome": "yes", "consensusReached": true, "agreementRatio": 0.82 },
+        "resolutionRef": { "resolvedOutcome": "yes", "resolutionTransactionHash": "stellar-tx-1" }
+      }
+    ],
+    "decision_context": {
+      "batchId": "MKT-1:1737033600000:ab12cd34",
+      "consensusContext": { "finalOutcome": "yes", "consensusReached": true },
+      "resolutionRef": { "resolvedOutcome": "yes" },
+      "contributingProviders": ["coingecko", "chainlink"]
+    },
+    "legacy_resolution": false
+  }
+}
+```
+
+`legacy_resolution: true` marks a market that was resolved before this feature
+existed — it has no observation trail, and none is fabricated.
+
+## Frontend
+
+`ProviderProvenance` is a new sub-component of the existing `ResolutionPanel`
+(`frontend/src/components/ResolutionPanel/`). It fetches the provenance endpoint
+independently, so a provenance failure degrades to a placeholder without
+affecting the rest of the panel. For each resolution attempt it renders every
+provider observation with a valid / stale / rejected badge, the value,
+confidence, receipt time, rejection reason, and a `contributed` / `excluded`
+marker, followed by the consensus decision context.
+
+## Security & retention
+
+- `OracleProvenanceRecorder.sanitizeMetadata()` recursively redacts any key
+  matching `api key`, `secret`, `token`, `authorization`, `auth`, `password`,
+  `passphrase`, `credential`, `bearer`, `cookie`, `session`, `private key`, or
+  `signature`, and caps string length and object depth.
+- Raw provider HTTP responses, headers, and request credentials are never
+  persisted — only the normalized `data` block the provider returns, sanitized.
+- The API returns the same sanitized `responseMetadata`; it never exposes
+  provider credentials.
+
+## Historical reconstruction rules
+
+- Observation and verdict fields are immutable after creation. A response that
+  was rejected stays rejected even if a later attempt (new `batchId`) produces a
+  valid answer. A stale response stays recorded as stale.
+- Only `contributedToResolution` and `resolutionRef` are added after the fact,
+  and only once the real resolution transition has succeeded. Linkage never
+  changes a record's `validationStatus`.
+
+## Known limitations
+
+- Provenance is recorded on the consensus / multi-source path
+  (`resolveWithFallback`, oracle retry queue). The single-provider direct path
+  (`market.oracleSource` with no `oracleConfig.sources`) performs no
+  cross-provider validation and is not recorded.
+- Markets resolved before this feature have no provenance; the API reports
+  `legacy_resolution: true` rather than backfilling.

--- a/frontend/src/components/ResolutionPanel/ProviderProvenance.tsx
+++ b/frontend/src/components/ResolutionPanel/ProviderProvenance.tsx
@@ -1,0 +1,303 @@
+// Oracle Data Provenance & Verification Layer (#241)
+//
+// Renders the off-chain oracle-provider decision path for a market: every
+// provider response that entered the resolution pipeline, its validation
+// verdict (valid / stale / rejected) and reason, and which observations
+// actually contributed to the final resolution.
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle2, Clock, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:5001';
+
+type ValidationStatus = 'valid' | 'stale' | 'rejected';
+
+interface Observation {
+  provider: string;
+  providerRequestId: string | null;
+  batchId: string;
+  receivedAt: string;
+  normalizedOutcome: 'yes' | 'no' | null;
+  confidence: number | null;
+  numericValue: number | null;
+  validationStatus: ValidationStatus;
+  rejectionReason: string | null;
+  rejectionDetail: string | null;
+  stale: boolean;
+  freshness: { ageMs: number | null; maxAgeMs: number | null } | null;
+  participatedInConsensus: boolean;
+  contributedToResolution: boolean;
+}
+
+interface Attempt {
+  batchId: string;
+  recordedAt: string;
+  observationCount: number;
+  acceptedCount: number;
+  rejectedCount: number;
+  staleCount: number;
+  contributingProviders: string[];
+  consensusContext: {
+    finalOutcome: string | null;
+    consensusReached: boolean;
+    agreementRatio: number | null;
+    consensusThreshold: number | null;
+  } | null;
+}
+
+interface ProvenanceData {
+  marketId: string;
+  resolution: {
+    status: string;
+    resolvedOutcome: string | null;
+    resolutionTransactionHash: string | null;
+  };
+  observations: Observation[];
+  attempts: Attempt[];
+  decision_context: {
+    batchId: string;
+    contributingProviders: string[];
+    consensusContext: Attempt['consensusContext'];
+  } | null;
+  legacy_resolution: boolean;
+}
+
+interface ProviderProvenanceProps {
+  marketId: string;
+}
+
+async function fetchProvenance(marketId: string): Promise<ProvenanceData> {
+  const res = await fetch(`${API_BASE}/api/markets/${marketId}/resolution/provenance`);
+  if (!res.ok) {
+    throw new Error(`Provenance fetch failed: ${res.status} ${res.statusText}`);
+  }
+  const json = await res.json();
+  return json.data as ProvenanceData;
+}
+
+function formatTimestamp(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return ts;
+  }
+}
+
+const STATUS_META: Record<
+  ValidationStatus,
+  { label: string; className: string; Icon: typeof CheckCircle2 }
+> = {
+  valid: {
+    label: 'Valid',
+    className: 'bg-success/10 text-success border-success/30',
+    Icon: CheckCircle2,
+  },
+  stale: {
+    label: 'Stale',
+    className: 'bg-warning/10 text-warning border-warning/30',
+    Icon: Clock,
+  },
+  rejected: {
+    label: 'Rejected',
+    className: 'bg-destructive/10 text-destructive border-destructive/30',
+    Icon: XCircle,
+  },
+};
+
+function ObservationRow({ observation }: { observation: Observation }) {
+  const meta = STATUS_META[observation.validationStatus];
+  const { Icon } = meta;
+
+  return (
+    <div className="px-4 py-3 rounded-lg bg-muted/20 border border-border/40 space-y-1.5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-medium capitalize truncate">{observation.provider}</span>
+          {observation.providerRequestId && (
+            <span className="text-xs text-muted-foreground font-mono truncate">
+              {observation.providerRequestId}
+            </span>
+          )}
+        </div>
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border shrink-0',
+            meta.className,
+          )}
+        >
+          <Icon className="w-3 h-3" />
+          {meta.label}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+        {observation.normalizedOutcome && (
+          <span>
+            value:{' '}
+            <span className="uppercase font-medium text-foreground">
+              {observation.normalizedOutcome}
+            </span>
+          </span>
+        )}
+        {observation.numericValue !== null && <span>{observation.numericValue}</span>}
+        {observation.confidence !== null && (
+          <span>confidence {(observation.confidence * 100).toFixed(0)}%</span>
+        )}
+        <span>received {formatTimestamp(observation.receivedAt)}</span>
+      </div>
+
+      {observation.rejectionDetail && (
+        <p className="text-xs text-muted-foreground">
+          {observation.rejectionReason && (
+            <span className="font-mono">{observation.rejectionReason}</span>
+          )}
+          {observation.rejectionReason ? ' — ' : ''}
+          {observation.rejectionDetail}
+        </p>
+      )}
+
+      <p
+        className={cn(
+          'text-xs font-medium',
+          observation.contributedToResolution ? 'text-success' : 'text-muted-foreground',
+        )}
+      >
+        {observation.contributedToResolution
+          ? '→ contributed to final resolution'
+          : '→ excluded from final resolution'}
+      </p>
+    </div>
+  );
+}
+
+export function ProviderProvenance({ marketId }: ProviderProvenanceProps) {
+  const { data, isLoading, isError } = useQuery<ProvenanceData, Error>({
+    queryKey: ['resolution-provenance', marketId],
+    queryFn: () => fetchProvenance(marketId),
+    retry: 1,
+  });
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="glass-card p-5 space-y-2">
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Oracle Data Provenance
+        </h3>
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          Provenance data unavailable.
+        </p>
+      </div>
+    );
+  }
+
+  if (data.legacy_resolution) {
+    return (
+      <div className="glass-card p-5 space-y-2">
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Oracle Data Provenance
+        </h3>
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          This market was resolved before provenance tracking was enabled. No oracle observation
+          trail is available.
+        </p>
+      </div>
+    );
+  }
+
+  if (data.observations.length === 0) {
+    return (
+      <div className="glass-card p-5 space-y-2">
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Oracle Data Provenance
+        </h3>
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          No oracle observations have been recorded for this market yet.
+        </p>
+      </div>
+    );
+  }
+
+  // Observations already arrive oldest-first; group them by resolution attempt.
+  const attemptsById = new Map<string, Observation[]>();
+  for (const obs of data.observations) {
+    const list = attemptsById.get(obs.batchId) ?? [];
+    list.push(obs);
+    attemptsById.set(obs.batchId, list);
+  }
+
+  return (
+    <div className="glass-card p-5 space-y-4">
+      <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+        Oracle Data Provenance
+      </h3>
+
+      {data.attempts.map((attempt) => {
+        const observations = attemptsById.get(attempt.batchId) ?? [];
+        const ctx = attempt.consensusContext;
+
+        return (
+          <div key={attempt.batchId} className="space-y-3">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">
+                Resolution attempt · {formatTimestamp(attempt.recordedAt)}
+              </span>
+              <span className="text-success">{attempt.acceptedCount} valid</span>
+              <span className="text-warning">{attempt.staleCount} stale</span>
+              <span className="text-destructive">{attempt.rejectedCount} rejected</span>
+            </div>
+
+            <div className="space-y-2">
+              {observations.map((obs) => (
+                <ObservationRow key={`${obs.batchId}-${obs.provider}`} observation={obs} />
+              ))}
+            </div>
+
+            {ctx && (
+              <div className="px-4 py-3 rounded-lg bg-primary/5 border border-primary/20 text-xs space-y-1">
+                <p className="font-medium text-foreground">
+                  Final decision:{' '}
+                  <span className="uppercase">{ctx.finalOutcome ?? 'not reached'}</span>
+                </p>
+                <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-muted-foreground">
+                  <span>
+                    consensus {ctx.consensusReached ? 'reached' : 'not reached'}
+                  </span>
+                  {ctx.agreementRatio !== null && (
+                    <span>agreement {(ctx.agreementRatio * 100).toFixed(1)}%</span>
+                  )}
+                  {ctx.consensusThreshold !== null && (
+                    <span>threshold {(ctx.consensusThreshold * 100).toFixed(0)}%</span>
+                  )}
+                  {attempt.contributingProviders.length > 0 && (
+                    <span>
+                      contributing: {attempt.contributingProviders.join(', ')}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {data.resolution.resolvedOutcome && (
+        <div className="flex items-start gap-2 text-xs text-muted-foreground pt-1">
+          <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span>
+            Rejected and stale observations are retained for audit and never influence the outcome.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ResolutionPanel/index.tsx
+++ b/frontend/src/components/ResolutionPanel/index.tsx
@@ -8,6 +8,7 @@ import { AggregatedResult } from './AggregatedResult';
 import { ResolutionStatus } from './ResolutionStatus';
 import { AuditTrail } from './AuditTrail';
 import { HealthSummary } from './HealthSummary';
+import { ProviderProvenance } from './ProviderProvenance';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:5001';
 
@@ -174,6 +175,8 @@ export function ResolutionPanel({ marketId }: ResolutionPanelProps) {
       />
 
       <AggregatedResult aggregatedResult={resolution.aggregated_result} />
+
+      <ProviderProvenance marketId={marketId} />
 
       <AuditTrail auditTrail={resolution.audit_trail} />
 


### PR DESCRIPTION
Adds an append-oriented provenance trail for the off-chain oracle-provider layer (issue #241), complementary to the existing on-chain ResolutionEvent transparency trail.

- OracleProvenanceRecord model (oracle_provenance collection): one record per provider response with validation verdict (valid/rejected/stale), structured rejection reason + detail, freshness, consensus participation, and a post-resolution link to the market resolution it contributed to.
- OracleProvenanceRecorder service: derives per-provider verdicts from the OracleConsensusEngine decision, sanitizes provider metadata (never persists credentials), and links a recorded batch to a resolution only after the real state transition succeeds. Best-effort — never fails a resolution.
- oracleService.aggregateResults records a provenance batch and exposes its id; backgroundJobs links the batch after market.save().
- GET /api/markets/:id/resolution/provenance exposes the full decision path.
- ResolutionPanel gains a ProviderProvenance sub-component.
- Tests: multi-provider, stale, invalid/outlier, resolution linkage, API, credential redaction. Docs in docs/oracle-data-provenance.md.


