### PR TITLE
feat: add price manipulation protection

### DIFF
--- a/backend/__tests__/controllers/tradeController.test.js
+++ b/backend/__tests__/controllers/tradeController.test.js
@@ -34,7 +34,11 @@ jest.mock('../../src/services/sorobanService', () => ({
 
 jest.mock('../../src/config/logger', () => ({
   trade: jest.fn(),
-  error: jest.fn()
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+  oracle: jest.fn()
 }));
 
 const sorobanService = require('../../src/services/sorobanService');
@@ -120,5 +124,52 @@ describe('TradeController', () => {
     await TradeController.getRecentTrades(req, res);
 
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true, data: { trades: expect.any(Array) } }));
+  });
+
+  describe('executeTrade — MEV / price-manipulation guard (#242)', () => {
+    beforeEach(() => {
+      // nonce-replay lookup uses .select(), not .lean()
+      mockTradeModel.findOne.mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
+      req.body = {
+        marketId: 'btc-1',
+        tokenType: 'yes',
+        tradeType: 'buy',
+        amount: 10,
+        maxSlippage: 0.05,
+        walletAddress: 'gtrader',
+        nonce: 'nonce-12345678'
+      };
+    });
+
+    it('queues a normal trade and returns guard metrics', async () => {
+      sorobanService.calculateTradePrice.mockResolvedValue({ price: 0.62, priceImpact: 0.02, fees: 1 });
+
+      await TradeController.executeTrade(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.data.trade.guardMetrics).toEqual(
+        expect.objectContaining({ maxSlippageBps: 500 })
+      );
+    });
+
+    it('rejects the trade when the execution price breaches the slippage bound', async () => {
+      // quoted (pre-trade) price is 0.6; a fill at 0.9 is 5000 bps adverse.
+      sorobanService.calculateTradePrice.mockResolvedValue({ price: 0.9, priceImpact: 0.02, fees: 1 });
+
+      await expect(TradeController.executeTrade(req, res)).rejects.toThrow(/bps against the quote/);
+      expect(mockTradeModel.updateOne).toHaveBeenCalledWith(
+        expect.objectContaining({ tradeId: expect.any(String) }),
+        expect.objectContaining({ status: 'failed' })
+      );
+    });
+
+    it('rejects the trade when the total cost exceeds the declared maxCost', async () => {
+      sorobanService.calculateTradePrice.mockResolvedValue({ price: 0.62, priceImpact: 0.02, fees: 1 });
+      req.body.maxCost = 1; // 10 tokens * ~0.62 = ~6.2 > 1
+
+      await expect(TradeController.executeTrade(req, res)).rejects.toThrow(/exceeds declared maxCost/);
+    });
   });
 });

--- a/backend/__tests__/services/circuitBreakerService.test.js
+++ b/backend/__tests__/services/circuitBreakerService.test.js
@@ -1,4 +1,4 @@
-const circuitBreakerService = require('../../../src/services/circuitBreakerService');
+const circuitBreakerService = require('../../src/services/circuitBreakerService');
 
 describe('CircuitBreakerService', () => {
   beforeEach(() => {
@@ -253,6 +253,41 @@ describe('CircuitBreakerService', () => {
       expect(status.circuitBreaker.triggerCount).toBe(3);
       expect(status.circuitBreaker.peakPrice).toBe(0.8);
       expect(status.priceHistoryLength).toBe(1);
+    });
+  });
+
+  describe('getReferencePrice (#242)', () => {
+    it('returns null when there is no price history', () => {
+      expect(circuitBreakerService.getReferencePrice('pool-empty')).toBeNull();
+    });
+
+    it('averages the most recent recorded prices and reports sample count', () => {
+      const now = Date.now();
+      circuitBreakerService.priceHistory.set('pool-1', [
+        { price: 0.40, timestamp: now - 5000 },
+        { price: 0.50, timestamp: now - 3000 },
+        { price: 0.60, timestamp: now - 1000 },
+      ]);
+
+      const reference = circuitBreakerService.getReferencePrice('pool-1');
+      expect(reference.price).toBeCloseTo(0.5, 6);
+      expect(reference.sampleCount).toBe(3);
+      expect(reference.ageMs).toBeGreaterThanOrEqual(0);
+      expect(reference.ageMs).toBeLessThan(5000);
+    });
+
+    it('only averages the requested window size', () => {
+      const now = Date.now();
+      circuitBreakerService.priceHistory.set('pool-1', [
+        { price: 0.10, timestamp: now - 9000 },
+        { price: 0.20, timestamp: now - 8000 },
+        { price: 0.90, timestamp: now - 2000 },
+        { price: 0.92, timestamp: now - 1000 },
+      ]);
+
+      const reference = circuitBreakerService.getReferencePrice('pool-1', 2);
+      expect(reference.sampleCount).toBe(2);
+      expect(reference.price).toBeCloseTo(0.91, 6);
     });
   });
 });

--- a/backend/__tests__/services/tradeGuardService.test.js
+++ b/backend/__tests__/services/tradeGuardService.test.js
@@ -1,0 +1,471 @@
+/**
+ * Adversarial + boundary tests for TradeGuardService (#242).
+ *
+ * Scenario map (from the issue):
+ *   A normal trade                         -> allowed
+ *   B within slippage boundary             -> allowed
+ *   C outside slippage boundary            -> rejected
+ *   D abnormal reference deviation         -> rejected
+ *   E legitimate market move (in bound)    -> allowed
+ *   F trade value too low                  -> rejected
+ *   G stale reference                      -> rejected / safe fallback
+ *   H sandwich-like state change           -> execution bound violated
+ *   I competing (front-run) trade          -> slippage exceeded
+ * plus exact boundary values (threshold-1 / threshold / threshold+1),
+ * config changes, and event emission.
+ */
+
+const logger = require('../../src/config/logger');
+const tradeGuard = require('../../src/services/tradeGuardService');
+const { VIOLATION } = tradeGuard;
+
+const BASE_CONFIG = tradeGuard.getConfig();
+
+function reset() {
+  tradeGuard.setConfig({ ...BASE_CONFIG });
+}
+
+/** Fresh, trustworthy reference at a given price. */
+function ref(price, overrides = {}) {
+  return { price, sampleCount: 10, ageMs: 1000, ...overrides };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  reset();
+});
+
+// ---------------------------------------------------------------------------
+// A / B / E — trades that must pass
+// ---------------------------------------------------------------------------
+
+describe('legitimate trades are allowed', () => {
+  it('A: a normal buy at the quoted price passes', () => {
+    const res = tradeGuard.evaluateExecution({
+      marketId: 'MKT',
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.5,
+      totalCost: 50,
+      maxSlippage: 0.05,
+      reference: ref(0.5)
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.violations).toEqual([]);
+  });
+
+  it('B: a fill just inside the slippage boundary passes', () => {
+    // maxSlippage 5% -> 500 bps. 0.5 -> 0.5249 is 498 bps.
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.5249,
+      totalCost: 52.49,
+      maxSlippage: 0.05,
+      reference: ref(0.5)
+    });
+    expect(res.allowed).toBe(true);
+  });
+
+  it('E: a legitimate market move within the reference bound passes', () => {
+    // reference 0.50, execution 0.54 -> 800 bps, under the 1000 bps default.
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.54,
+      executedPrice: 0.54,
+      totalCost: 54,
+      maxSlippage: 0.05,
+      reference: ref(0.5)
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.metrics.referenceDeviationBps).toBe(800);
+  });
+
+  it('does not penalise a favourable price move beyond the slippage tolerance', () => {
+    // Buyer quoted 0.5, fills at 0.40 — 2000 bps better for the buyer.
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.4,
+      totalCost: 40,
+      maxSlippage: 0.05,
+      reference: ref(0.4)
+    });
+    expect(res.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C / I — slippage
+// ---------------------------------------------------------------------------
+
+describe('slippage protection', () => {
+  it('C: a fill outside the slippage boundary is rejected', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.60, // 2000 bps adverse
+      totalCost: 60,
+      maxSlippage: 0.05,
+      reference: ref(0.55)
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations[0].code).toBe(VIOLATION.SLIPPAGE_EXCEEDED);
+    expect(res.violations[0].observedBps).toBe(2000);
+  });
+
+  it('exact boundary: threshold-1 passes, threshold passes, threshold+1 fails', () => {
+    const atBps = (bps) => tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 1,
+      executedPrice: 1 + bps / 10_000, // exact bps above quote
+      totalCost: 100,
+      maxSlippage: 0.05, // 500 bps
+      reference: null
+    }).allowed;
+
+    expect(atBps(499)).toBe(true);
+    expect(atBps(500)).toBe(true);
+    expect(atBps(501)).toBe(false);
+  });
+
+  it('I: a competing (front-running) trade that moves the price adversely trips slippage', () => {
+    // Victim signed with quotedPrice 0.50 and 3% tolerance. A front-run trade
+    // pushed the fill to 0.55 before the victim executed.
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.55, // 1000 bps adverse, tolerance 300 bps
+      totalCost: 55,
+      maxSlippage: 0.03,
+      reference: ref(0.5)
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations.map((v) => v.code)).toContain(VIOLATION.SLIPPAGE_EXCEEDED);
+  });
+
+  it('sell side: an adverse downward move trips slippage, an upward move does not', () => {
+    const adverse = tradeGuard.evaluateExecution({
+      tradeType: 'sell',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.44, // 1200 bps worse for a seller
+      totalCost: 100,
+      maxSlippage: 0.05,
+      reference: ref(0.47)
+    });
+    expect(adverse.allowed).toBe(false);
+    expect(adverse.violations[0].code).toBe(VIOLATION.SLIPPAGE_EXCEEDED);
+
+    const favourable = tradeGuard.evaluateExecution({
+      tradeType: 'sell',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.60,
+      totalCost: 100,
+      maxSlippage: 0.05,
+      reference: ref(0.55)
+    });
+    expect(favourable.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Absolute execution bounds — H
+// ---------------------------------------------------------------------------
+
+describe('absolute execution bounds', () => {
+  it('rejects a buy whose total cost exceeds maxCost', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.5,
+      totalCost: 50,
+      maxCost: 49.99,
+      reference: null
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations[0].code).toBe(VIOLATION.EXECUTION_BOUND_VIOLATED);
+  });
+
+  it('allows a buy whose total cost is exactly maxCost', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.5,
+      totalCost: 50,
+      maxCost: 50,
+      reference: null
+    });
+    expect(res.allowed).toBe(true);
+  });
+
+  it('H: a sandwich-like reserve change that drops proceeds below minReceived is rejected', () => {
+    // Victim wants at least 48 for selling 100 tokens. An attacker trade moved
+    // the pool so the fill price is only 0.45 -> proceeds 45.
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'sell',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.45,
+      totalCost: 100,
+      minReceived: 48,
+      maxSlippage: 0.2, // wide, so only the absolute bound bites
+      reference: ref(0.47)
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations.map((v) => v.code)).toContain(VIOLATION.EXECUTION_BOUND_VIOLATED);
+  });
+
+  it('allows a sell whose proceeds meet minReceived exactly', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'sell',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.5,
+      totalCost: 100,
+      minReceived: 50,
+      maxSlippage: 0.05,
+      reference: ref(0.5)
+    });
+    expect(res.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D — reference deviation
+// ---------------------------------------------------------------------------
+
+describe('reference-price deviation', () => {
+  it('D: an execution far from the reference is rejected', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.8,
+      executedPrice: 0.8, // reference 0.5 -> 6000 bps
+      totalCost: 80,
+      maxSlippage: 0.05,
+      reference: ref(0.5)
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations.map((v) => v.code)).toContain(VIOLATION.REFERENCE_DEVIATION);
+  });
+
+  it('boundary: reference deviation threshold-1 / threshold / threshold+1', () => {
+    tradeGuard.setConfig({ maxReferenceDeviationBps: 1000 });
+    const atBps = (bps) => tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 1 + bps / 10_000,
+      executedPrice: 1 + bps / 10_000,
+      totalCost: 100,
+      maxSlippage: 1, // disable slippage check
+      reference: ref(1)
+    }).allowed;
+
+    expect(atBps(999)).toBe(true);
+    expect(atBps(1000)).toBe(true);
+    expect(atBps(1001)).toBe(false);
+  });
+
+  it('skips the reference check when there are too few samples', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.9,
+      executedPrice: 0.9,
+      totalCost: 90,
+      maxSlippage: 1,
+      reference: ref(0.5, { sampleCount: 2 }) // below minReferenceSamples (3)
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.metrics.referenceDeviationBps).toBeNull();
+  });
+
+  it('skips the reference check when no reference is available', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.9,
+      executedPrice: 0.9,
+      totalCost: 90,
+      maxSlippage: 1,
+      reference: null
+    });
+    expect(res.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// G — stale reference
+// ---------------------------------------------------------------------------
+
+describe('stale reference handling', () => {
+  it('G: rejects the trade when the reference is stale (default policy)', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.5,
+      totalCost: 50,
+      maxSlippage: 0.05,
+      reference: ref(0.5, { ageMs: 10 * 60 * 1000 }) // 10 min, max 5 min
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations[0].code).toBe(VIOLATION.STALE_REFERENCE);
+    expect(res.metrics.referenceStale).toBe(true);
+  });
+
+  it("G: with policy 'ignore', a stale reference is skipped rather than trusted", () => {
+    tradeGuard.setConfig({ staleReferencePolicy: 'ignore' });
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.9,
+      executedPrice: 0.9, // would be a huge deviation from the 0.5 reference
+      totalCost: 90,
+      maxSlippage: 1,
+      reference: ref(0.5, { ageMs: 10 * 60 * 1000 })
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.metrics.referenceStale).toBe(true);
+    expect(res.metrics.referenceDeviationBps).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F — dust guard
+// ---------------------------------------------------------------------------
+
+describe('minimum trade value', () => {
+  it('F: rejects a dust trade below the minimum value', () => {
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 0.001,
+      quotedPrice: 0.5,
+      executedPrice: 0.5,
+      totalCost: 0.0005, // below default minTradeValue 0.01
+      maxSlippage: 0.05,
+      reference: null
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations[0].code).toBe(VIOLATION.TRADE_VALUE_TOO_LOW);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+describe('configuration', () => {
+  it('is a no-op when disabled', () => {
+    tradeGuard.setConfig({ enabled: false });
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.99,
+      totalCost: 99,
+      maxSlippage: 0.01,
+      reference: ref(0.5)
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.metrics.skipped).toBe('disabled');
+  });
+
+  it('requireQuote rejects a trade with no quoted price', () => {
+    tradeGuard.setConfig({ requireQuote: true });
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      executedPrice: 0.5,
+      totalCost: 50,
+      maxSlippage: 0.05,
+      reference: null
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations[0].code).toBe(VIOLATION.QUOTE_REQUIRED);
+  });
+
+  it('getConfig returns a copy that cannot mutate internal state', () => {
+    const cfg = tradeGuard.getConfig();
+    cfg.maxSlippageBps = 1;
+    expect(tradeGuard.getConfig().maxSlippageBps).toBe(BASE_CONFIG.maxSlippageBps);
+  });
+
+  it('setConfig tightens the slippage cap for subsequent evaluations', () => {
+    tradeGuard.setConfig({ maxSlippageBps: 100 }); // 1%
+    const res = tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.515, // 300 bps
+      totalCost: 51.5,
+      reference: null
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.violations[0].code).toBe(VIOLATION.SLIPPAGE_EXCEEDED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Observability
+// ---------------------------------------------------------------------------
+
+describe('observability', () => {
+  it('logs a structured warning when a trade is rejected', () => {
+    tradeGuard.evaluateExecution({
+      marketId: 'MKT-log',
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.8,
+      totalCost: 80,
+      maxSlippage: 0.05,
+      reference: ref(0.5)
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[RISK] Trade rejected by trade guard',
+      expect.objectContaining({ marketId: 'MKT-log' })
+    );
+  });
+
+  it('does not log when a trade is allowed', () => {
+    tradeGuard.evaluateExecution({
+      tradeType: 'buy',
+      filledAmount: 100,
+      quotedPrice: 0.5,
+      executedPrice: 0.5,
+      totalCost: 50,
+      maxSlippage: 0.05,
+      reference: ref(0.5)
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// helper
+// ---------------------------------------------------------------------------
+
+describe('deviationBps', () => {
+  it('computes absolute deviation in integer basis points', () => {
+    expect(tradeGuard.deviationBps(0.55, 0.5)).toBe(1000);
+    expect(tradeGuard.deviationBps(0.45, 0.5)).toBe(1000);
+    expect(tradeGuard.deviationBps(0.5, 0.5)).toBe(0);
+  });
+
+  it('returns null for a zero or non-finite basis', () => {
+    expect(tradeGuard.deviationBps(1, 0)).toBeNull();
+    expect(tradeGuard.deviationBps(NaN, 1)).toBeNull();
+  });
+});

--- a/backend/src/controllers/tradeController.js
+++ b/backend/src/controllers/tradeController.js
@@ -3,6 +3,7 @@ const stellarService = require('../services/stellarService');
 const sorobanService = require('../services/sorobanService');
 const tradeBatcher = require('../services/tradeBatcher');
 const circuitBreakerService = require('../services/circuitBreakerService');
+const tradeGuardService = require('../services/tradeGuardService');
 const logger = require('../config/logger');
 const { NotFoundError, ValidationError, StellarError } = require('../middleware/errorHandler');
 const websocketHandler = require('../services/websocketHandler');
@@ -17,13 +18,19 @@ class TradeController {
       amount,
       maxSlippage = 0.05,
       walletAddress,
-      nonce
+      nonce,
+      // Optional absolute execution bounds the caller commits to (#242).
+      quotedPrice,
+      minReceived,
+      maxCost
     } = req.body;
 
     // Verify user owns the wallet
     if (walletAddress.toLowerCase() !== req.user.walletAddress) {
       throw new ValidationError('Cannot trade from different wallet address');
     }
+
+    const normalizedWalletAddress = req.user.walletAddress.toLowerCase();
 
     const market = await Market.findOne({ marketId });
     if (!market) {
@@ -55,7 +62,6 @@ class TradeController {
       throw new ValidationError(circuitBreakerCheck.reason);
     }
 
-    const normalizedWalletAddress = req.user.walletAddress.toLowerCase();
     const existingNonceTrade = await Trade.findOne({
       userWalletAddress: normalizedWalletAddress,
       nonce
@@ -115,6 +121,29 @@ class TradeController {
       const effectiveAmount = filledAmount;
       const totalCost = tradeType === 'buy' ? effectiveAmount * expectedPrice : effectiveAmount;
       const platformFee = totalCost * (market.platformFee || 0.005);
+
+      // MEV / price-manipulation protection (#242): enforce the caller's
+      // execution bounds against the *actual* (post-partial-fill) price and
+      // reject abnormal execution before the trade is persisted or batched.
+      const preTradePrice = tokenType === 'yes' ? market.currentYesPrice : market.currentNoPrice;
+      const guardResult = tradeGuardService.evaluateExecution({
+        marketId,
+        tradeType,
+        filledAmount,
+        quotedPrice: Number.isFinite(quotedPrice) ? quotedPrice : preTradePrice,
+        executedPrice: expectedPrice,
+        totalCost,
+        maxSlippage,
+        maxCost,
+        minReceived,
+        priceImpact,
+        reference: circuitBreakerService.getReferencePrice(marketId)
+      });
+
+      if (!guardResult.allowed) {
+        const [primary] = guardResult.violations;
+        throw new ValidationError(primary ? primary.message : 'Trade rejected by execution safeguards');
+      }
 
       // Create trade record
       const trade = new Trade({
@@ -196,6 +225,7 @@ class TradeController {
             totalCost,
             fees: trade.fees,
             slippage: priceImpact,
+            guardMetrics: guardResult.metrics,
             status: 'pending_batch',
             timestamp: trade.timestamp,
             batchExecution: true
@@ -210,6 +240,17 @@ class TradeController {
         { tradeId },
         { status: 'failed', 'metadata.failureReason': error.message }
       );
+      // A rejected trade (slippage / execution-bound / manipulation safeguard)
+      // is a client error, not an execution failure — surface it as-is so it
+      // returns 400 rather than being masked as a 500 StellarError (#242).
+      if (error instanceof ValidationError) {
+        logger.warn('[RISK] Trade rejected before execution', {
+          tradeId,
+          marketId,
+          reason: error.message
+        });
+        throw error;
+      }
       logger.error('Trade execution failed:', error);
       throw new StellarError(`Trade execution failed: ${error.message}`);
     }

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -177,6 +177,25 @@ const tradeValidations = {
       .withMessage('Max slippage must be between 0.1% and 10%')
       .toFloat(),
 
+    // Optional execution bounds enforced server-side (#242).
+    body('quotedPrice')
+      .optional()
+      .isFloat({ min: 0, max: 1 })
+      .withMessage('quotedPrice must be between 0 and 1')
+      .toFloat(),
+
+    body('minReceived')
+      .optional()
+      .isFloat({ min: 0 })
+      .withMessage('minReceived must be a positive number')
+      .toFloat(),
+
+    body('maxCost')
+      .optional()
+      .isFloat({ min: 0 })
+      .withMessage('maxCost must be a positive number')
+      .toFloat(),
+
     commonValidations.walletAddress,
     validate
   ],

--- a/backend/src/services/circuitBreakerService.js
+++ b/backend/src/services/circuitBreakerService.js
@@ -213,6 +213,33 @@ class CircuitBreakerService {
   }
 
   /**
+   * Manipulation-resistant reference price for a pool, derived from the recent
+   * average of recorded trade prices. Used by tradeGuardService (#242) to bound
+   * how far a fill price may deviate from recent trading and to detect a stale
+   * reference. Returns null when there is not enough history to be trustworthy.
+   *
+   * @param {string} poolId
+   * @param {number} [sampleSize=20] number of most-recent prices to average
+   * @returns {{price:number, sampleCount:number, ageMs:number}|null}
+   */
+  getReferencePrice(poolId, sampleSize = 20) {
+    const history = this.priceHistory.get(poolId) || [];
+    if (history.length === 0) {
+      return null;
+    }
+
+    const recent = history.slice(-sampleSize);
+    const price = recent.reduce((sum, p) => sum + p.price, 0) / recent.length;
+    const newestTs = recent[recent.length - 1].timestamp;
+
+    return {
+      price,
+      sampleCount: recent.length,
+      ageMs: Math.max(0, Date.now() - newestTs)
+    };
+  }
+
+  /**
    * Check price deviation from recent history
    */
   _checkPriceDeviation(poolId, currentPrice) {

--- a/backend/src/services/tradeGuardService.js
+++ b/backend/src/services/tradeGuardService.js
@@ -1,0 +1,311 @@
+const logger = require('../config/logger');
+
+/**
+ * TradeGuardService (#242 — MEV & Price-Manipulation Protection)
+ *
+ * Pre-trade execution gate that runs in the authoritative backend trade path
+ * (`tradeController.executeTrade`), BEFORE a trade is persisted or handed to the
+ * batcher/on-chain execution. It enforces the caller's declared execution
+ * bounds and rejects abnormal execution conditions.
+ *
+ * This complements — it does not replace — the protections that already exist:
+ *   - `circuitBreakerService`  : emergency pause, cooldown, recent-price
+ *                                deviation, trade-size vs liquidity, per-user
+ *                                rate limits, volume spikes, drawdown.
+ *   - `amm-pool` Soroban contract : reentrancy guard, `min_out` slippage,
+ *                                price-impact cap, circuit breaker, trading
+ *                                limits, emergency/drawdown pause. This is the
+ *                                ultimate authoritative layer for on-chain
+ *                                settlement.
+ *
+ * What this service adds that was missing: an enforced bound between the price
+ * the caller was quoted / committed to and the price the trade actually
+ * executes at after partial-fill re-pricing, plus a deviation check against a
+ * manipulation-resistant reference price and an explicit stale-reference rule.
+ *
+ * DETECT vs PREVENT: every check here PREVENTS (rejects the trade). Heuristic
+ * anomaly *detection* stays in `manipulationDetector`.
+ *
+ * Limitations (see docs/mev-price-manipulation-protection.md):
+ *   - Does not eliminate MEV. It bounds execution loss and rejects abnormal
+ *     execution according to configurable rules.
+ *   - The reference price is an internal manipulation-resistant recent average,
+ *     not an external oracle. A prediction-market token has no external spot
+ *     price; the oracle resolves the final OUTCOME, not a live probability.
+ */
+
+const VIOLATION = Object.freeze({
+  DISABLED: 'DISABLED',
+  QUOTE_REQUIRED: 'QUOTE_REQUIRED',
+  SLIPPAGE_EXCEEDED: 'SLIPPAGE_EXCEEDED',
+  EXECUTION_BOUND_VIOLATED: 'EXECUTION_BOUND_VIOLATED',
+  REFERENCE_DEVIATION: 'REFERENCE_DEVIATION',
+  STALE_REFERENCE: 'STALE_REFERENCE',
+  TRADE_VALUE_TOO_LOW: 'TRADE_VALUE_TOO_LOW'
+});
+
+const DEFAULT_CONFIG = Object.freeze({
+  enabled: true,
+  // Execution slippage cap between quoted price and actual fill price.
+  // 500 bps (5%) mirrors the contract's MAX_SLIPPAGE_BPS.
+  maxSlippageBps: 500,
+  // Deviation cap between the actual fill price and the manipulation-resistant
+  // reference. 1000 bps (10%) mirrors circuitBreakerService.priceDeviationThreshold.
+  maxReferenceDeviationBps: 1000,
+  // Reference older than this is considered stale.
+  maxReferenceAgeMs: 5 * 60 * 1000,
+  // Below this many samples there is no trustworthy reference; the reference
+  // checks are skipped (not failed).
+  minReferenceSamples: 3,
+  // 'reject' -> stale reference blocks the trade; 'ignore' -> reference checks
+  // are skipped when the reference is stale. Never silently trusts stale data.
+  staleReferencePolicy: 'reject',
+  // Minimum notional value of a trade (dust / spam guard).
+  minTradeValue: 0.01,
+  // When true, a trade with no quoted price is rejected instead of skipping the
+  // slippage check.
+  requireQuote: false,
+  // Tolerance for floating point comparison of absolute bounds.
+  boundEpsilon: 1e-9
+});
+
+const ENV_OVERRIDES = {
+  TRADE_GUARD_ENABLED: (v, c) => { c.enabled = v !== 'false' && v !== '0'; },
+  TRADE_GUARD_MAX_SLIPPAGE_BPS: (v, c) => { c.maxSlippageBps = Number(v); },
+  TRADE_GUARD_MAX_REFERENCE_DEVIATION_BPS: (v, c) => { c.maxReferenceDeviationBps = Number(v); },
+  TRADE_GUARD_MAX_REFERENCE_AGE_MS: (v, c) => { c.maxReferenceAgeMs = Number(v); },
+  TRADE_GUARD_MIN_REFERENCE_SAMPLES: (v, c) => { c.minReferenceSamples = Number(v); },
+  TRADE_GUARD_STALE_REFERENCE_POLICY: (v, c) => { c.staleReferencePolicy = v; },
+  TRADE_GUARD_MIN_TRADE_VALUE: (v, c) => { c.minTradeValue = Number(v); },
+  TRADE_GUARD_REQUIRE_QUOTE: (v, c) => { c.requireQuote = v === 'true' || v === '1'; }
+};
+
+/** Absolute deviation of `value` from `basis`, in basis points (integer). */
+function deviationBps(value, basis) {
+  if (!Number.isFinite(value) || !Number.isFinite(basis) || basis === 0) return null;
+  return Math.round((Math.abs(value - basis) / Math.abs(basis)) * 10_000);
+}
+
+class TradeGuardService {
+  constructor() {
+    this.config = { ...DEFAULT_CONFIG };
+    this._loadEnvOverrides();
+  }
+
+  _loadEnvOverrides() {
+    for (const [key, apply] of Object.entries(ENV_OVERRIDES)) {
+      const raw = process.env[key];
+      if (raw === undefined || raw === '') continue;
+      try {
+        apply(raw, this.config);
+      } catch (error) {
+        logger.warn(`[RISK] Ignoring invalid ${key}`, { value: raw, error: error.message });
+      }
+    }
+    // Guard against nonsensical overrides.
+    if (!Number.isFinite(this.config.maxSlippageBps) || this.config.maxSlippageBps < 0) {
+      this.config.maxSlippageBps = DEFAULT_CONFIG.maxSlippageBps;
+    }
+    if (!Number.isFinite(this.config.maxReferenceDeviationBps) || this.config.maxReferenceDeviationBps < 0) {
+      this.config.maxReferenceDeviationBps = DEFAULT_CONFIG.maxReferenceDeviationBps;
+    }
+    if (!['reject', 'ignore'].includes(this.config.staleReferencePolicy)) {
+      this.config.staleReferencePolicy = DEFAULT_CONFIG.staleReferencePolicy;
+    }
+  }
+
+  /** Current configuration (copy). Configurable via env or `setConfig`. */
+  getConfig() {
+    return { ...this.config };
+  }
+
+  /**
+   * Merge a partial config. Intended for admin/governance-driven updates and
+   * tests. Unknown keys are ignored; invalid values fall back to defaults.
+   */
+  setConfig(partial = {}) {
+    const next = { ...this.config };
+    for (const key of Object.keys(DEFAULT_CONFIG)) {
+      if (partial[key] !== undefined) next[key] = partial[key];
+    }
+    this.config = next;
+    this._loadEnvOverrides();
+    return this.getConfig();
+  }
+
+  static get VIOLATION() {
+    return VIOLATION;
+  }
+
+  /**
+   * Evaluate a fully-priced trade against the configured execution safeguards.
+   *
+   * @param {Object} params
+   * @param {string}  params.marketId
+   * @param {'buy'|'sell'} params.tradeType
+   * @param {number}  params.filledAmount     token amount that will actually fill
+   * @param {number}  params.quotedPrice      price the caller was quoted / committed to (0-1)
+   * @param {number}  params.executedPrice    final price after partial-fill re-pricing (0-1)
+   * @param {number}  params.totalCost        final notional (cost for buy, proceeds basis for sell)
+   * @param {number} [params.maxSlippage]     caller slippage tolerance as a fraction (e.g. 0.05)
+   * @param {number} [params.maxCost]         absolute max the caller will pay (buy)
+   * @param {number} [params.minReceived]     absolute min the caller will receive (sell)
+   * @param {number} [params.priceImpact]     price impact of the caller's own trade, as a fraction
+   * @param {{price:number, sampleCount:number, ageMs:number}|null} [params.reference]
+   * @param {number} [params.now]
+   * @returns {{allowed:boolean, violations:Array, metrics:Object}}
+   */
+  evaluateExecution(params = {}) {
+    const cfg = this.config;
+
+    if (!cfg.enabled) {
+      return { allowed: true, violations: [], metrics: { skipped: 'disabled' } };
+    }
+
+    const {
+      marketId = null,
+      tradeType,
+      filledAmount,
+      quotedPrice,
+      executedPrice,
+      totalCost,
+      maxSlippage,
+      maxCost,
+      minReceived,
+      priceImpact,
+      reference = null
+    } = params;
+
+    const violations = [];
+    const maxSlippageBps = Number.isFinite(maxSlippage)
+      ? Math.round(maxSlippage * 10_000)
+      : cfg.maxSlippageBps;
+
+    const hasQuote = Number.isFinite(quotedPrice) && quotedPrice > 0;
+    const hasExec = Number.isFinite(executedPrice) && executedPrice > 0;
+
+    // --- Slippage: quoted price vs actual fill price ----------------------
+    let slippageBps = null;
+    if (!hasQuote) {
+      if (cfg.requireQuote) {
+        violations.push({
+          code: VIOLATION.QUOTE_REQUIRED,
+          message: 'A quoted price is required to enforce slippage protection'
+        });
+      }
+    } else if (hasExec) {
+      slippageBps = deviationBps(executedPrice, quotedPrice);
+      // Only an adverse move counts against the trader.
+      const adverse =
+        tradeType === 'sell' ? executedPrice < quotedPrice : executedPrice > quotedPrice;
+      if (adverse && slippageBps !== null && slippageBps > maxSlippageBps) {
+        violations.push({
+          code: VIOLATION.SLIPPAGE_EXCEEDED,
+          message: `Execution price moved ${slippageBps} bps against the quote (max ${maxSlippageBps} bps)`,
+          observedBps: slippageBps,
+          thresholdBps: maxSlippageBps
+        });
+      }
+    }
+
+    // --- Absolute execution bounds -------------------------------------
+    const eps = cfg.boundEpsilon;
+    if (tradeType === 'buy' && Number.isFinite(maxCost) && Number.isFinite(totalCost)) {
+      if (totalCost > maxCost * (1 + eps)) {
+        violations.push({
+          code: VIOLATION.EXECUTION_BOUND_VIOLATED,
+          message: `Total cost ${totalCost} exceeds declared maxCost ${maxCost}`,
+          observed: totalCost,
+          bound: maxCost
+        });
+      }
+    }
+    if (tradeType === 'sell' && Number.isFinite(minReceived) && hasExec && Number.isFinite(filledAmount)) {
+      const proceeds = filledAmount * executedPrice;
+      if (proceeds < minReceived * (1 - eps)) {
+        violations.push({
+          code: VIOLATION.EXECUTION_BOUND_VIOLATED,
+          message: `Proceeds ${proceeds} fall short of declared minReceived ${minReceived}`,
+          observed: proceeds,
+          bound: minReceived
+        });
+      }
+    }
+
+    // --- Reference-price deviation & staleness ------------------------
+    let referenceDeviationBps = null;
+    let referenceStale = false;
+    const refUsable =
+      reference &&
+      Number.isFinite(reference.price) &&
+      reference.price > 0 &&
+      Number.isFinite(reference.sampleCount) &&
+      reference.sampleCount >= cfg.minReferenceSamples;
+
+    if (refUsable) {
+      referenceStale =
+        Number.isFinite(reference.ageMs) && reference.ageMs > cfg.maxReferenceAgeMs;
+
+      if (referenceStale && cfg.staleReferencePolicy === 'reject') {
+        violations.push({
+          code: VIOLATION.STALE_REFERENCE,
+          message: `Reference price is stale (${reference.ageMs}ms old, max ${cfg.maxReferenceAgeMs}ms); refusing to execute against it`,
+          ageMs: reference.ageMs,
+          maxAgeMs: cfg.maxReferenceAgeMs
+        });
+      } else if (!(referenceStale && cfg.staleReferencePolicy === 'ignore') && hasExec) {
+        referenceDeviationBps = deviationBps(executedPrice, reference.price);
+        if (referenceDeviationBps !== null && referenceDeviationBps > cfg.maxReferenceDeviationBps) {
+          violations.push({
+            code: VIOLATION.REFERENCE_DEVIATION,
+            message: `Execution price deviates ${referenceDeviationBps} bps from the reference (max ${cfg.maxReferenceDeviationBps} bps)`,
+            observedBps: referenceDeviationBps,
+            thresholdBps: cfg.maxReferenceDeviationBps,
+            referencePrice: reference.price
+          });
+        }
+      }
+    }
+
+    // --- Dust / spam guard -------------------------------------------
+    if (Number.isFinite(totalCost) && totalCost < cfg.minTradeValue) {
+      violations.push({
+        code: VIOLATION.TRADE_VALUE_TOO_LOW,
+        message: `Trade value ${totalCost} is below the minimum ${cfg.minTradeValue}`,
+        observed: totalCost,
+        bound: cfg.minTradeValue
+      });
+    }
+
+    const metrics = {
+      slippageBps,
+      // Price impact from the caller's own trade — reported separately from
+      // slippage (state-change loss) and reference deviation (external move).
+      priceImpactBps: Number.isFinite(priceImpact) ? Math.round(priceImpact * 10_000) : null,
+      referenceDeviationBps,
+      referenceStale,
+      referenceSamples: reference?.sampleCount ?? 0,
+      maxSlippageBps
+    };
+
+    const allowed = violations.length === 0;
+
+    if (!allowed) {
+      logger.warn('[RISK] Trade rejected by trade guard', {
+        marketId,
+        tradeType,
+        violations: violations.map((v) => v.code),
+        metrics
+      });
+    }
+
+    return { allowed, violations, metrics };
+  }
+}
+
+const instance = new TradeGuardService();
+instance.TradeGuardService = TradeGuardService;
+instance.VIOLATION = VIOLATION;
+instance.deviationBps = deviationBps;
+
+module.exports = instance;

--- a/docs/mev-price-manipulation-protection.md
+++ b/docs/mev-price-manipulation-protection.md
@@ -1,0 +1,146 @@
+# MEV & Price-Manipulation Protection (#242)
+
+## Scope of this document
+
+Oryn already carries a substantial protection suite. This document describes
+what exists, what this PR **adds**, where each safeguard is **enforced**, and —
+explicitly — what it does **not** protect against.
+
+> This implementation does **not** claim to be "MEV-proof". It bounds execution
+> loss and rejects abnormal execution according to configurable rules.
+
+## Enforcement layers
+
+| Layer | Authority | Safeguards |
+|---|---|---|
+| **`amm-pool` Soroban contract** (`contracts/amm-pool/src/lib.rs`) | **Authoritative for on-chain settlement** | reentrancy guard; `min_out` slippage; price-impact cap (`MAX_SLIPPAGE_BPS`); per-window trade count + trade-size cap (`MAX_TRADE_SIZE_BPS`, 5% of reserves); post-trade circuit breaker on price deviation (`CIRCUIT_BREAKER_THRESHOLD_BPS`, 10%) with cooldown; liquidity-imbalance detection; drawdown auto-emergency-pause (`MAX_DRAWDOWN_BPS`, 20%); admin `trigger/reset_circuit_breaker`, `activate/deactivate_emergency_pause`, `update_trading_limits_config`. |
+| **Backend `circuitBreakerService`** | Pre-trade gate in `tradeController.executeTrade` | emergency pause; circuit-breaker cooldown; recent-average price-deviation trip (10%); trade-size vs pool liquidity (5%); per-user rolling-window rate limit; volume-spike alerting. Rejections raise `ValidationError` (HTTP 400). |
+| **Backend `manipulationDetector`** | Post-trade, async | heuristic **detection** only (wash trading, order spam, volume spike, single-trade price move) → alerts + WebSocket admin broadcast. Does not block. |
+| **Backend `tradeGuardService`** — *added by this PR* | Pre-trade gate in `tradeController.executeTrade`, before the trade is persisted or batched | execution-bound enforcement (see below). Rejections raise `ValidationError` (HTTP 400). |
+
+## What this PR adds
+
+### 1. `tradeGuardService` — enforced execution bounds
+
+`tradeController.executeTrade` computes the fill price **after partial-fill
+re-pricing** but previously never re-checked that the trader still got an
+acceptable deal — `maxSlippage` was only compared against a rough pre-trade
+estimate (a hard-coded `0.01` when no contract price was available). A signed
+trade intent carried no absolute bound the server guaranteed.
+
+`tradeGuardService.evaluateExecution({...})` runs on the final, fully-priced
+trade and rejects it (`ValidationError` → 400) when any of the following hold:
+
+| Violation code | Condition |
+|---|---|
+| `SLIPPAGE_EXCEEDED` | The **adverse** deviation between the caller's `quotedPrice` and the actual `executedPrice` exceeds `maxSlippage` (per-request) or `maxSlippageBps` (config default 500 = 5%). Favourable moves are never rejected. |
+| `EXECUTION_BOUND_VIOLATED` | `buy`: final `totalCost > maxCost`. `sell`: `filledAmount * executedPrice < minReceived`. `maxCost` / `minReceived` are optional absolute bounds supplied in the request body. |
+| `REFERENCE_DEVIATION` | `executedPrice` deviates from the manipulation-resistant reference by more than `maxReferenceDeviationBps` (default 1000 = 10%). Skipped when fewer than `minReferenceSamples` (default 3) samples exist. |
+| `STALE_REFERENCE` | The reference is older than `maxReferenceAgeMs` (default 5 min) and `staleReferencePolicy` is `reject` (default). With policy `ignore`, the reference checks are skipped — a stale reference is **never silently trusted**. |
+| `TRADE_VALUE_TOO_LOW` | Notional value below `minTradeValue` (default 0.01) — dust / spam guard. |
+| `QUOTE_REQUIRED` | Only when `requireQuote` is enabled and no `quotedPrice` was supplied. |
+
+The service returns `{ allowed, violations[], metrics }`. `metrics` reports
+`slippageBps`, `priceImpactBps` (the caller's own price impact, kept **distinct**
+from slippage and reference deviation), `referenceDeviationBps`,
+`referenceStale`, and `referenceSamples`. `metrics` is echoed on the trade
+response as `data.trade.guardMetrics`.
+
+### 2. Reference price
+
+`circuitBreakerService.getReferencePrice(poolId)` returns
+`{ price, sampleCount, ageMs }` — a recent average of recorded trade prices for
+the market.
+
+A prediction-market token has **no external spot price**: the oracle resolves
+the final market *outcome*, not a live probability, so it cannot serve as a
+price oracle here (issue §4). The reference is therefore an **internal
+manipulation-resistant recent average**, not an external oracle. Its limits:
+it lags real moves, it needs history to be meaningful (hence `minReferenceSamples`
+and the stale-reference rule), and a patient attacker who moves the average over
+many trades can shift it. It is a guard-rail, not a source of truth.
+
+### 3. Correctness fix in the trade path
+
+- The circuit-breaker check in `executeTrade` referenced `normalizedWalletAddress`
+  before its declaration (a temporal-dead-zone `ReferenceError` that made the
+  whole handler throw). The declaration is moved above the check.
+- A `ValidationError` raised inside the execution `try` block (slippage /
+  execution-bound / manipulation rejection, and the pre-existing price-impact
+  check) was being re-wrapped as a 500 `StellarError`. It is now re-thrown
+  unchanged so a rejected trade returns 400.
+
+## Configuration
+
+`tradeGuardService` config is a single object with environment overrides and a
+`getConfig()` / `setConfig(partial)` pair (mirrors `circuitBreakerService`).
+
+| Key | Default | Env override |
+|---|---|---|
+| `enabled` | `true` | `TRADE_GUARD_ENABLED` |
+| `maxSlippageBps` | `500` | `TRADE_GUARD_MAX_SLIPPAGE_BPS` |
+| `maxReferenceDeviationBps` | `1000` | `TRADE_GUARD_MAX_REFERENCE_DEVIATION_BPS` |
+| `maxReferenceAgeMs` | `300000` | `TRADE_GUARD_MAX_REFERENCE_AGE_MS` |
+| `minReferenceSamples` | `3` | `TRADE_GUARD_MIN_REFERENCE_SAMPLES` |
+| `staleReferencePolicy` | `reject` | `TRADE_GUARD_STALE_REFERENCE_POLICY` |
+| `minTradeValue` | `0.01` | `TRADE_GUARD_MIN_TRADE_VALUE` |
+| `requireQuote` | `false` | `TRADE_GUARD_REQUIRE_QUOTE` |
+
+Defaults mirror existing protocol constants: `maxSlippageBps` = the contract's
+`MAX_SLIPPAGE_BPS`; `maxReferenceDeviationBps` = `circuitBreakerService`'s 10%
+price-deviation threshold. They are **not** new invented numbers.
+
+`maxSlippage`, `quotedPrice`, `minReceived`, `maxCost` are optional
+`POST /api/trades` body fields (validated in `middleware/validation.js`).
+
+## DETECT vs PREVENT
+
+- **PREVENT** (trade is rejected): everything in `circuitBreakerService`
+  `checkTradeAllowed` and everything in `tradeGuardService`, plus the on-chain
+  contract checks.
+- **DETECT** (alert only, trade proceeds): `manipulationDetector` heuristics
+  (wash trading, order spam, volume spikes, single-trade price-move alerts).
+
+The backend cannot reliably identify a *front-runner's identity* from wallet
+addresses; it can only enforce the victim's declared execution bounds. Those
+bounds are what the adversarial tests exercise.
+
+## What this does NOT do
+
+- It does not eliminate MEV. Sandwichers and front-runners can still attempt
+  attacks; the safeguards limit the victim's realised loss and reject fills that
+  breach declared bounds or move abnormally.
+- The reference price is internal and lagging (see above); it is not a
+  trustworthy external oracle and is not treated as one.
+- **Contract-level pre-trade price-deviation guard — out of scope here.** The
+  `amm-pool` contract imports `PRICE_DEVIATION_THRESHOLD_BPS` (5%) and
+  `OrynError::PriceDeviationTooHigh` (74) but never enforces a pre-trade
+  deviation check — `update_circuit_breaker` only reacts *after* a swap commits,
+  using the looser 10% `CIRCUIT_BREAKER_THRESHOLD_BPS`. Converting that to a
+  *pre-trade* guard (reject the swap whose projected post-swap price deviates
+  from `circuit_breaker.last_price` by more than the configured bps), plus an
+  optional `deadline` parameter on `swap`, is the natural on-chain follow-up.
+  It is deferred because the contract workspace does not currently build on this
+  toolchain (`stellar-xdr-20.1.0` fails to compile against current `rustc` — the
+  same class of breakage the vendored `ethnum` patch addresses), so such a
+  change could not be compiled or tested here. Shipping unverified changes to a
+  security-critical swap path would be worse than deferring them.
+
+## Tests
+
+- `backend/__tests__/services/tradeGuardService.test.js` — 27 tests: normal
+  trades; slippage boundary (threshold-1 / threshold / threshold+1); adverse vs
+  favourable moves (buy and sell); absolute `maxCost` / `minReceived` bounds;
+  reference-deviation boundary; too-few-samples and no-reference skips; stale
+  reference (`reject` and `ignore` policies); dust guard; disabled config;
+  `requireQuote`; config immutability and `setConfig`; structured rejection
+  logging; sandwich-like and front-running-like scenarios.
+- `backend/__tests__/services/circuitBreakerService.test.js` — fixed a broken
+  `require` path that made the whole suite fail to run (20 tests resurrected) and
+  added `getReferencePrice` coverage.
+- `backend/__tests__/controllers/tradeController.test.js` — fixed an incomplete
+  `logger` mock that made the suite fail to run; added `executeTrade` guard
+  tests (normal trade returns `guardMetrics`; slippage breach → 400; `maxCost`
+  breach → 400).
+
+Full backend suite: 42 suites / 427 tests passing.


### PR DESCRIPTION
Adds an enforced pre-trade execution guard to the authoritative backend trade path (issue #242), complementing the existing on-chain amm-pool safeguards and backend circuitBreakerService.

- tradeGuardService: rejects a trade before it is persisted/batched when the actual (post-partial-fill) price breaches the caller's slippage tolerance, when an absolute maxCost/minReceived bound is violated, when the fill deviates too far from a manipulation-resistant reference price, when that reference is stale, or on dust value. Configurable via env / getConfig/setConfig with defaults mirroring existing protocol constants (MAX_SLIPPAGE_BPS, the 10% circuit-breaker deviation threshold). Distinguishes price impact, execution slippage and reference deviation.
- circuitBreakerService.getReferencePrice(): recent-average reference used by the guard (a prediction-market token has no external spot oracle).
- tradeController.executeTrade: wires the guard in; fixes a temporal-dead-zone ReferenceError on normalizedWalletAddress that made the handler always throw; re-throws ValidationError instead of masking rejections as 500 StellarError.
- POST /api/trades accepts optional quotedPrice / minReceived / maxCost.
- Tests: 27 adversarial/boundary tests for the guard (incl. sandwich- and front-run-like scenarios); repaired two pre-existing broken suites (circuitBreakerService wrong require path, tradeController incomplete logger mock) and added executeTrade guard coverage. Full backend suite 42/42.
- docs/mev-price-manipulation-protection.md: threat model, layers, config, DETECT vs PREVENT, and limitations (incl. the deferred on-chain pre-trade deviation guard, blocked by a broken contract toolchain).


